### PR TITLE
add  `client.baseURL` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ console.log(hat);
 
 const hat = await MakeHat({ inches: 12 }, { baseURL: "https://api.example.com"); // We can also override the globally configured `baseURL` with a different value
 console.log(hat);
+
 #### Connecting to an existing Twirp server and only need a JavaScript or TypeScript client?
 
 1. Get your service's `.proto` file (or define one).

--- a/README.md
+++ b/README.md
@@ -173,16 +173,17 @@ const hat = await MakeHat({ inches: 12 }, { baseURL: "http://localhost:8080" });
 console.log(hat);
 ```
 
-You might want to configure baseURL globally for all API calls:
+`baseURL` can be configured globally, instead of providing it for every RPC call site:
+
 ```ts
 import { client } from "twirpscript";
 client.baseURL = "http://localhost:8080";
 
-const = await MakeHat({ inches: 12 }); // We can omit the baseURL config since it's already set
+const hat = await MakeHat({ inches: 12 }); // We can omit `baseURL` because it has already been set
+console.log(hat);
 
-```
-
-
+const hat = await MakeHat({ inches: 12 }, { baseURL: "https://api.example.com"); // We can also override the globally configured `baseURL` with a different value
+console.log(hat);
 #### Connecting to an existing Twirp server and only need a JavaScript or TypeScript client?
 
 1. Get your service's `.proto` file (or define one).

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ const hat = await MakeHat({ inches: 12 }, { baseURL: "http://localhost:8080" });
 console.log(hat);
 ```
 
+You might want to configure baseURL globally for all API calls:
+```ts
+import { client } from "twirpscript";
+client.baseURL = "http://localhost:8080";
+
+const = await MakeHat({ inches: 12 }); // We can omit the baseURL config since it's already set
+
+```
+
+
 #### Connecting to an existing Twirp server and only need a JavaScript or TypeScript client?
 
 1. Get your service's `.proto` file (or define one).


### PR DESCRIPTION
Added a usage example for `client.baseURL` as most users are expected to look for it.

I've found myself trying to configure the baseURL through the client middleware, only later to find out that there's a `client.baseURL` configuration which is currently undocumented.
