### PR TITLE
Change file output to be written asynchronously

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFile as fsWriteFile } from "fs";
 import {
   CodeGeneratorRequest,
   CodeGeneratorResponse,
@@ -45,4 +45,4 @@ request.getProtoFileList().forEach((fileDescriptorProto) => {
   );
 });
 
-writeFileSync(process.stdout.fd, response.serializeBinary());
+fsWriteFileSync(process.stdout.fd, response.serializeBinary(), () => {});


### PR DESCRIPTION
Fix for issue #7 

From my understanding the stdout is non-blocking and trying to write to it synchronously most of the time results in node.js throwing an error as it cannot write to the output while it's busy probably doing something else.

Changing the file write to be asynchrous seems to fix the issue. I couldn't reproduce the error anymore.