### PR TITLE
Remove transitive lib.dom.d.ts dependency

### DIFF
--- a/src/runtime/client/index.ts
+++ b/src/runtime/client/index.ts
@@ -90,10 +90,17 @@ interface RpcTransportOpts {
   body: string | Uint8Array | undefined | null;
 }
 
+/**
+ * Subset of [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) from Fetch API. Redefined so that end users don't need to include lib.dom.d.ts in server only applications.
+ */
+interface Headers {
+  get(name: string): string | null;
+}
+
 export interface RpcTransportResponse {
   arrayBuffer: () => Promise<ArrayBuffer>;
   json: () => Promise<unknown>;
-  readonly headers: Pick<Headers, "get">;
+  readonly headers: Headers;
   readonly ok: boolean;
   readonly status: number;
   text: () => Promise<string>;


### PR DESCRIPTION
Redefines Header interface so that TwirpScript does not transitively
depend on lib.dom.d.ts. This allows end users to use TwirpScript in
server only contexts without adjusting their tsconfig to include
lib.dom.

Fixes #48.