### PR TITLE
docs: fix error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ const Haberdasher: HaberdasherService = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(HaberdasherService);
+export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
 ```
 
 #### 5. Connect your service to your application server


### PR DESCRIPTION
This is a small documentation PR to fix a naming issue in the README example.