### PR TITLE
fix: invalid filepaths generated when using custom proto root

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -178,9 +178,7 @@ try {
 
   const protoExt = config.language === "typescript" ? "pb.ts" : "pb.js";
   const protosBeforeCompile = Object.fromEntries(
-    findFiles(destination, protoExt)
-      .map((filepath) => relative(config.root, filepath))
-      .map((file) => [file, checksum(file)])
+    findFiles(destination, protoExt).map((file) => [file, checksum(file)])
   );
 
   const protoc = spawnSync(
@@ -207,9 +205,10 @@ protoc \
     process.exit(1);
   }
 
-  const protosAfterCompile = findFiles(destination, protoExt)
-    .map((filepath) => relative(config.root, filepath))
-    .map((file) => [file, checksum(file)]);
+  const protosAfterCompile = findFiles(destination, protoExt).map((file) => [
+    file,
+    checksum(file),
+  ]);
 
   const created = protosAfterCompile.filter(
     (file) => !protosBeforeCompile[file[0]]


### PR DESCRIPTION
This commit fixes #88. 

When using a custom root the mapping of proto filepaths to their relative directory produces invalid filepaths. It appears this relative mapping is redundant and as a result this commit removes it.