### PR TITLE
remove naming suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,9 @@ If you have an existing Twirp server you're connecting to and only need a client
 `src/server/haberdasher/index.ts`
 
 ```ts
-import {
-  HaberdasherService,
-  createHaberdasherHandler,
-} from "../../protos/haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "../../protos/haberdasher.pb";
 
-const Haberdasher: HaberdasherService = {
+const haberdasher: Haberdasher = {
   MakeHat: (size) => {
     return {
       inches: size.inches,
@@ -197,7 +194,7 @@ const Haberdasher: HaberdasherService = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const haberdasherHandler = createHaberdasher(haberdasher);
 ```
 
 #### 5. Connect your service to your application server
@@ -207,11 +204,11 @@ export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
 ```ts
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./haberdasher";
+import { haberdasherHandler } from "./haberdasher";
 
 const PORT = 8080;
 
-const app = createTwirpServer([HaberdasherHandler]);
+const app = createTwirpServer([haberdasherHandler]);
 
 createServer(app).listen(PORT, () =>
   console.log(`Server listening on port ${PORT}`)
@@ -309,12 +306,12 @@ Servers can be configured by passing a configuration object to `createTwirpServe
 ```ts
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./haberdasher";
+import { haberdasherHandler } from "./haberdasher";
 
 const PORT = 8080;
 
 // This removes the "/twirp" prefix in the RPC path
-const app = createTwirpServer([HaberdasherHandler], { prefix: "" });
+const app = createTwirpServer([haberdasherHandler], { prefix: "" });
 
 createServer(app).listen(PORT, () =>
   console.log(`Server listening on port ${PORT}`)
@@ -347,13 +344,10 @@ Custom fields can be added to the context object via [middleware](#middleware--i
 If you setup middleware similiar to the [authentication middleware example](https://github.com/tatethurston/TwirpScript#example-3), you could read the `currentUser` `username` property in your service handler. See the [authentication example](https://github.com/tatethurston/twirpscript/tree/main/examples/authentication) for a full application.
 
 ```ts
-import {
-  HaberdasherService,
-  createHaberdasherHandler,
-} from "../../protos/haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "../../protos/haberdasher.pb";
 import { Context } from "../some-path-to-your-definition";
 
-const Haberdasher: HaberdasherService<Context> = {
+const haberdasher: Haberdasher<Context> = {
   MakeHat: (size, ctx) => {
     return {
       inches: size.inches,
@@ -363,7 +357,7 @@ const Haberdasher: HaberdasherService<Context> = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(HaberdasherService);
+export const haberdasherHandler = createHaberdasher(haberdasher);
 ```
 
 ### Middleware / Interceptors
@@ -425,18 +419,18 @@ The middleware handler will receive `req`, `context` and `next` parameters. `req
 ```ts
 import { createServer } from "http";
 import { createTwirpServer, TwirpError } from "twirpscript";
-import { AuthenticationHandler } from "./authentication";
+import { authenticationHandler } from "./authentication";
 
 export interface Context {
   currentUser: { username: string };
 }
 
-const services = [AuthenticationHandler]
+const services = [authenticationHandler]
 const app = createTwirpServer<Context, typeof services>(services);
 
 app.use(async (req, ctx, next) => {
   // exception so unauthenticated users can authenticate
-  if (ctx.service.name === AuthenticationHandler.name) {
+  if (ctx.service.name === authenticationHandler.name) {
     return next();
   }
 
@@ -537,11 +531,11 @@ response) have been written. Called with the current `context` and the response.
 ```ts
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./haberdasher";
+import { habderdasherHandler } from "./haberdasher";
 
 const PORT = 8080;
 
-const app = createTwirpServer([HaberdasherHandler]);
+const app = createTwirpServer([habderdasherHandler]);
 
 app.on("responseSent", (ctx) => {
   // log or report

--- a/clientcompat/src/clientcompat.pb.ts
+++ b/clientcompat/src/clientcompat.pb.ts
@@ -70,17 +70,15 @@ export async function NoopMethodJSON(
 }
 
 //========================================//
-//         CompatService Service          //
+//             CompatService              //
 //========================================//
 
-export interface CompatServiceService<Context = unknown> {
+export interface CompatService<Context = unknown> {
   Method: (req: Req, context: Context) => Promise<Resp> | Resp;
   NoopMethod: (empty: Empty, context: Context) => Promise<Empty> | Empty;
 }
 
-export function createCompatServiceHandler<Context>(
-  service: CompatServiceService<Context>
-) {
+export function createCompatService<Context>(service: CompatService<Context>) {
   return {
     name: "twirp.clientcompat.CompatService",
     methods: {

--- a/examples/authentication/src/client/index.tsx
+++ b/examples/authentication/src/client/index.tsx
@@ -65,7 +65,7 @@ const App: FC = () => {
 
   return (
     <div>
-      <h1>Haberdasher Service</h1>
+      <h1>Haberdasher </h1>
       <h3>Current User: </h3>
       {user ? (
         <div>

--- a/examples/authentication/src/protos/authentication.pb.ts
+++ b/examples/authentication/src/protos/authentication.pb.ts
@@ -52,10 +52,10 @@ export async function LoginJSON(
 }
 
 //========================================//
-//         Authentication Service         //
+//             Authentication             //
 //========================================//
 
-export interface AuthenticationService<Context = unknown> {
+export interface Authentication<Context = unknown> {
   /**
    * Login in a user
    */
@@ -65,8 +65,8 @@ export interface AuthenticationService<Context = unknown> {
   ) => Promise<CurrentUser> | CurrentUser;
 }
 
-export function createAuthenticationHandler<Context>(
-  service: AuthenticationService<Context>
+export function createAuthentication<Context>(
+  service: Authentication<Context>
 ) {
   return {
     name: "Authentication",

--- a/examples/authentication/src/protos/haberdasher.pb.ts
+++ b/examples/authentication/src/protos/haberdasher.pb.ts
@@ -48,22 +48,20 @@ export async function MakeHatJSON(
 }
 
 //========================================//
-//          Haberdasher Service           //
+//              Haberdasher               //
 //========================================//
 
 /**
  * Haberdasher service makes hats for clients.
  */
-export interface HaberdasherService<Context = unknown> {
+export interface Haberdasher<Context = unknown> {
   /**
    * MakeHat produces a hat of mysterious, randomly-selected color!
    */
   MakeHat: (size: Size, context: Context) => Promise<Hat> | Hat;
 }
 
-export function createHaberdasherHandler<Context>(
-  service: HaberdasherService<Context>
-) {
+export function createHaberdasher<Context>(service: Haberdasher<Context>) {
   return {
     name: "Haberdasher",
     methods: {

--- a/examples/authentication/src/server/index.ts
+++ b/examples/authentication/src/server/index.ts
@@ -1,15 +1,15 @@
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { AuthenticationHandler, HaberdasherHandler } from "./services";
+import { authenticationHandler, habderdasherHandler } from "./services";
 import { Context } from "./context";
 import { cors, requireAuthentication } from "./middleware";
 
 const PORT = 8080;
-const services = [AuthenticationHandler, HaberdasherHandler];
+const services = [authenticationHandler, habderdasherHandler];
 
 const app = createTwirpServer<Context, typeof services>(services)
   .use(cors)
-  .use(requireAuthentication({ exceptions: [AuthenticationHandler.name] }));
+  .use(requireAuthentication({ exceptions: [authenticationHandler.name] }));
 
 createServer(app).listen(PORT, () =>
   console.log(`Server listening on port ${PORT}`)

--- a/examples/authentication/src/server/middleware/requireAuthentication.ts
+++ b/examples/authentication/src/server/middleware/requireAuthentication.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from "http";
 import { Middleware, TwirpErrorResponse } from "twirpscript";
 import { Context } from "../context";
-import { getCurrentUser, UnauthenticatedUser } from "../services";
+import { getCurrentUser, unauthenticatedUser } from "../services";
 
 interface RequireAuthenticationOpts {
   exceptions: string[];
@@ -13,7 +13,7 @@ export function requireAuthentication({
   return async (req, ctx, next) => {
     for (let exception of exceptions) {
       if (ctx.service?.name === exception) {
-        ctx.currentUser = UnauthenticatedUser;
+        ctx.currentUser = unauthenticatedUser;
         return next();
       }
     }

--- a/examples/authentication/src/server/services/authentication/index.ts
+++ b/examples/authentication/src/server/services/authentication/index.ts
@@ -1,6 +1,6 @@
 import {
-  AuthenticationService,
-  createAuthenticationHandler,
+  Authentication,
+  createAuthentication,
   CurrentUser,
   Credentials,
 } from "../../../protos/authentication.pb";
@@ -27,7 +27,7 @@ function login(credentials: Credentials): CurrentUser | undefined {
 /**
  * Sentinal value for unauthenticated routes.
  */
-export const UnauthenticatedUser: CurrentUser = {
+export const unauthenticatedUser: CurrentUser = {
   username: "",
   token: "",
 };
@@ -41,7 +41,7 @@ export function getCurrentUser(
   return sessions.find((s) => s.token === token);
 }
 
-export const Authentication: AuthenticationService = {
+export const authentication: Authentication = {
   Login: (credentials) => {
     const user = login(credentials);
     if (!user) {
@@ -54,5 +54,4 @@ export const Authentication: AuthenticationService = {
   },
 };
 
-export const AuthenticationHandler =
-  createAuthenticationHandler(Authentication);
+export const authenticationHandler = createAuthentication(authentication);

--- a/examples/authentication/src/server/services/haberdasher/index.ts
+++ b/examples/authentication/src/server/services/haberdasher/index.ts
@@ -1,14 +1,11 @@
 import { Context } from "../../context";
-import {
-  HaberdasherService,
-  createHaberdasherHandler,
-} from "../../../protos/haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "../../../protos/haberdasher.pb";
 
 function choose<T>(list: T[]): T {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-export const Haberdasher: HaberdasherService<Context> = {
+export const haberdasher: Haberdasher<Context> = {
   MakeHat: (size, ctx) => {
     const username = ctx.currentUser.username;
     const hat = choose(["beanie", "fedora", "top hat", "cowboy", "beret"]);
@@ -22,4 +19,4 @@ export const Haberdasher: HaberdasherService<Context> = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const habderdasherHandler = createHaberdasher(haberdasher);

--- a/examples/authentication/src/server/services/haberdasher/test.ts
+++ b/examples/authentication/src/server/services/haberdasher/test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { Haberdasher } from ".";
+import { haberdasher } from ".";
 
 describe("Haberdasher", () => {
   describe("Haberdasher.MakeHat", () => {
@@ -7,7 +7,7 @@ describe("Haberdasher", () => {
       const size = { inches: 12 };
       const ctx = { currentUser: { username: "tate" } };
 
-      expect(Haberdasher.MakeHat(size, ctx)).toEqual(
+      expect(haberdasher.MakeHat(size, ctx)).toEqual(
         expect.objectContaining({
           inches: size.inches,
           name: expect.stringMatching("tate"),

--- a/examples/authentication/src/server/services/index.ts
+++ b/examples/authentication/src/server/services/index.ts
@@ -1,6 +1,6 @@
 export {
-  AuthenticationHandler,
+  authenticationHandler,
   getCurrentUser,
-  UnauthenticatedUser,
+  unauthenticatedUser,
 } from "./authentication";
-export { HaberdasherHandler } from "./haberdasher";
+export { habderdasherHandler } from "./haberdasher";

--- a/examples/aws-lambda/src/habderdasher.ts
+++ b/examples/aws-lambda/src/habderdasher.ts
@@ -1,10 +1,10 @@
-import { HaberdasherService, createHaberdasherHandler } from "./haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "./haberdasher.pb";
 
 function choose<T>(list: T[]): T {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-export const Haberdasher: HaberdasherService = {
+export const haberdasher: Haberdasher = {
   MakeHat: (size) => {
     return {
       inches: size.inches,
@@ -14,4 +14,4 @@ export const Haberdasher: HaberdasherService = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const habderdasherHandler = createHaberdasher(haberdasher);

--- a/examples/aws-lambda/src/haberdasher.pb.ts
+++ b/examples/aws-lambda/src/haberdasher.pb.ts
@@ -48,22 +48,20 @@ export async function MakeHatJSON(
 }
 
 //========================================//
-//          Haberdasher Service           //
+//              Haberdasher               //
 //========================================//
 
 /**
  * Haberdasher service makes hats for clients.
  */
-export interface HaberdasherService<Context = unknown> {
+export interface Haberdasher<Context = unknown> {
   /**
    * MakeHat produces a hat of mysterious, randomly-selected color!
    */
   MakeHat: (size: Size, context: Context) => Promise<Hat> | Hat;
 }
 
-export function createHaberdasherHandler<Context>(
-  service: HaberdasherService<Context>
-) {
+export function createHaberdasher<Context>(service: Haberdasher<Context>) {
   return {
     name: "Haberdasher",
     methods: {

--- a/examples/aws-lambda/src/index.ts
+++ b/examples/aws-lambda/src/index.ts
@@ -1,12 +1,12 @@
 import { createTwirpServerless } from "twirpscript";
-import { HaberdasherHandler } from "./habderdasher";
+import { habderdasherHandler } from "./habderdasher";
 import {
   Handler,
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
 } from "aws-lambda";
 
-const app = createTwirpServerless([HaberdasherHandler]);
+const app = createTwirpServerless([habderdasherHandler]);
 
 const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
   event

--- a/examples/javascript-fullstack/src/client/index.jsx
+++ b/examples/javascript-fullstack/src/client/index.jsx
@@ -22,7 +22,7 @@ const App = () => {
 
   return (
     <div>
-      <h1>Haberdasher Service</h1>
+      <h1>Haberdasher </h1>
       <h3>Hats: </h3>
       <ul>
         {hats.map((hat) => (

--- a/examples/javascript-fullstack/src/protos/haberdasher.pb.js
+++ b/examples/javascript-fullstack/src/protos/haberdasher.pb.js
@@ -40,7 +40,7 @@ export async function MakeHatJSON(size, config) {
   return response;
 }
 
-export function createHaberdasherHandler(service) {
+export function createHaberdasher(service) {
   return {
     name: "Haberdasher",
     methods: {

--- a/examples/javascript-fullstack/src/server/haberdasher/index.js
+++ b/examples/javascript-fullstack/src/server/haberdasher/index.js
@@ -1,10 +1,10 @@
-import { createHaberdasherHandler } from "../../protos/haberdasher.pb.js";
+import { createHaberdasher } from "../../protos/haberdasher.pb.js";
 
 function choose(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-export const Haberdasher = {
+export const haberdasher = {
   MakeHat: (size) => {
     return {
       inches: size.inches,
@@ -14,4 +14,4 @@ export const Haberdasher = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const habderdasherHandler = createHaberdasher(haberdasher);

--- a/examples/javascript-fullstack/src/server/index.js
+++ b/examples/javascript-fullstack/src/server/index.js
@@ -1,10 +1,10 @@
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./haberdasher/index.js";
+import { habderdasherHandler } from "./haberdasher/index.js";
 
 const PORT = 8080;
 
-const app = createTwirpServer([HaberdasherHandler]);
+const app = createTwirpServer([habderdasherHandler]);
 
 // CORS
 app.use(async (req, _ctx, next) => {

--- a/examples/server-to-server/src/protos/haberdasher.pb.ts
+++ b/examples/server-to-server/src/protos/haberdasher.pb.ts
@@ -48,22 +48,20 @@ export async function MakeHatJSON(
 }
 
 //========================================//
-//          Haberdasher Service           //
+//              Haberdasher               //
 //========================================//
 
 /**
  * Haberdasher service makes hats for clients.
  */
-export interface HaberdasherService<Context = unknown> {
+export interface Haberdasher<Context = unknown> {
   /**
    * MakeHat produces a hat of mysterious, randomly-selected color!
    */
   MakeHat: (size: Size, context: Context) => Promise<Hat> | Hat;
 }
 
-export function createHaberdasherHandler<Context>(
-  service: HaberdasherService<Context>
-) {
+export function createHaberdasher<Context>(service: Haberdasher<Context>) {
   return {
     name: "Haberdasher",
     methods: {

--- a/examples/server-to-server/src/server/haberdasher/index.ts
+++ b/examples/server-to-server/src/server/haberdasher/index.ts
@@ -1,13 +1,10 @@
-import {
-  HaberdasherService,
-  createHaberdasherHandler,
-} from "../../protos/haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "../../protos/haberdasher.pb";
 
 function choose<T>(list: T[]): T {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-export const Haberdasher: HaberdasherService = {
+export const haberdasher: Haberdasher = {
   MakeHat: (size) => {
     return {
       inches: size.inches,
@@ -17,4 +14,4 @@ export const Haberdasher: HaberdasherService = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const habderdasherHandler = createHaberdasher(haberdasher);

--- a/examples/server-to-server/src/server/haberdasher/test.ts
+++ b/examples/server-to-server/src/server/haberdasher/test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "@jest/globals";
-import { Haberdasher } from ".";
+import { haberdasher } from ".";
 
 describe("Haberdasher", () => {
   describe("Haberdasher.MakeHat", () => {
     it("makes hats", () => {
       const size = { inches: 12 };
 
-      expect(Haberdasher.MakeHat(size, {})).toEqual(
+      expect(haberdasher.MakeHat(size, {})).toEqual(
         expect.objectContaining({
           inches: size.inches,
         })

--- a/examples/server-to-server/src/server/index.ts
+++ b/examples/server-to-server/src/server/index.ts
@@ -1,10 +1,10 @@
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./haberdasher";
+import { habderdasherHandler } from "./haberdasher";
 
 const PORT = 8080;
 
-const app = createTwirpServer([HaberdasherHandler]);
+const app = createTwirpServer([habderdasherHandler]);
 
 createServer(app).listen(PORT, () =>
   console.log(`Server listening on port ${PORT}`)

--- a/examples/typescript-fullstack/src/client/index.tsx
+++ b/examples/typescript-fullstack/src/client/index.tsx
@@ -22,7 +22,7 @@ const App: FC = () => {
 
   return (
     <div>
-      <h1>Haberdasher Service</h1>
+      <h1>Haberdasher </h1>
       <h3>Hats: </h3>
       <ul>
         {hats.map((hat) => (

--- a/examples/typescript-fullstack/src/protos/haberdasher.pb.ts
+++ b/examples/typescript-fullstack/src/protos/haberdasher.pb.ts
@@ -48,22 +48,20 @@ export async function MakeHatJSON(
 }
 
 //========================================//
-//          Haberdasher Service           //
+//              Haberdasher               //
 //========================================//
 
 /**
  * Haberdasher service makes hats for clients.
  */
-export interface HaberdasherService<Context = unknown> {
+export interface Haberdasher<Context = unknown> {
   /**
    * MakeHat produces a hat of mysterious, randomly-selected color!
    */
   MakeHat: (size: Size, context: Context) => Promise<Hat> | Hat;
 }
 
-export function createHaberdasherHandler<Context>(
-  service: HaberdasherService<Context>
-) {
+export function createHaberdasher<Context>(service: Haberdasher<Context>) {
   return {
     name: "Haberdasher",
     methods: {

--- a/examples/typescript-fullstack/src/server/index.ts
+++ b/examples/typescript-fullstack/src/server/index.ts
@@ -1,10 +1,10 @@
 import { createServer } from "http";
 import { createTwirpServer } from "twirpscript";
-import { HaberdasherHandler } from "./services";
+import { habderdasherHandler } from "./services";
 
 const PORT = 8080;
 
-const app = createTwirpServer([HaberdasherHandler]);
+const app = createTwirpServer([habderdasherHandler]);
 
 // CORS
 app.use(async (req, _ctx, next) => {

--- a/examples/typescript-fullstack/src/server/services/haberdasher/index.ts
+++ b/examples/typescript-fullstack/src/server/services/haberdasher/index.ts
@@ -1,13 +1,10 @@
-import {
-  HaberdasherService,
-  createHaberdasherHandler,
-} from "../../../protos/haberdasher.pb";
+import { Haberdasher, createHaberdasher } from "../../../protos/haberdasher.pb";
 
 function choose<T>(list: T[]): T {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-export const Haberdasher: HaberdasherService = {
+export const haberdasher: Haberdasher = {
   MakeHat: (size) => {
     return {
       inches: size.inches,
@@ -17,4 +14,4 @@ export const Haberdasher: HaberdasherService = {
   },
 };
 
-export const HaberdasherHandler = createHaberdasherHandler(Haberdasher);
+export const habderdasherHandler = createHaberdasher(haberdasher);

--- a/examples/typescript-fullstack/src/server/services/haberdasher/test.ts
+++ b/examples/typescript-fullstack/src/server/services/haberdasher/test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "@jest/globals";
-import { Haberdasher } from ".";
+import { haberdasher } from ".";
 
 describe("Haberdasher", () => {
   describe("Haberdasher.MakeHat", () => {
     it("makes hats", () => {
       const size = { inches: 12 };
 
-      expect(Haberdasher.MakeHat(size, {})).toEqual(
+      expect(haberdasher.MakeHat(size, {})).toEqual(
         expect.objectContaining({
           inches: size.inches,
         })

--- a/examples/typescript-fullstack/src/server/services/index.ts
+++ b/examples/typescript-fullstack/src/server/services/index.ts
@@ -1,1 +1,1 @@
-export { HaberdasherHandler } from "./haberdasher";
+export { habderdasherHandler } from "./haberdasher";

--- a/src/autogenerate/index.ts
+++ b/src/autogenerate/index.ts
@@ -643,12 +643,12 @@ function writeServers(
   services.forEach((service) => {
     // print service types
     if (isTS) {
-      result += printHeading(`${service.name} Service`);
+      result += printHeading(`${service.name}`);
 
       if (service.comments?.leading) {
         result += printComments(service.comments.leading);
       }
-      result += `export interface ${service.name}Service<Context = unknown> {\n`;
+      result += `export interface ${service.name}<Context = unknown> {\n`;
       service.methods.forEach((method) => {
         if (method.comments?.leading) {
           result += printComments(method.comments.leading);
@@ -661,11 +661,9 @@ function writeServers(
 
     result += "\n";
 
-    result += `export function create${service.name}Handler${printIfTypescript(
+    result += `export function create${service.name}${printIfTypescript(
       "<Context>"
-    )}(service${printIfTypescript(
-      `: ${service.name}Service<Context>`
-    )}) { return {
+    )}(service${printIfTypescript(`: ${service.name}<Context>`)}) { return {
     name: '${[packageName, service.name].filter(Boolean).join(".")}',
     methods: {\n`;
     service.methods.forEach((method) => {

--- a/src/test-protos/__snapshots__/test.ts.snap
+++ b/src/test-protos/__snapshots__/test.ts.snap
@@ -350,7 +350,7 @@ export async function BarJSON(barRequest, config) {
   return response;
 }
 
-export function createTestServiceHandler(service) {
+export function createTestService(service) {
   return {
     name: \\"protobuf_unittest.TestService\\",
     methods: {
@@ -18752,7 +18752,7 @@ export async function BarJSON(empty, config) {
   return response;
 }
 
-export function createFooHandler(service) {
+export function createFoo(service) {
   return {
     name: \\"Foo\\",
     methods: {
@@ -19117,7 +19117,7 @@ export async function BarJSON(barRequest, config) {
   return response;
 }
 
-export function createTestServiceHandler(service) {
+export function createTestService(service) {
   return {
     name: \\"protobuf_unittest.TestService\\",
     methods: {
@@ -37547,7 +37547,7 @@ export async function BarJSON(empty, config) {
   return response;
 }
 
-export function createFooHandler(service) {
+export function createFoo(service) {
   return {
     name: \\"Foo\\",
     methods: {
@@ -37985,10 +37985,10 @@ export async function BarJSON(
 }
 
 //========================================//
-//          TestService Service           //
+//              TestService               //
 //========================================//
 
-export interface TestServiceService<Context = unknown> {
+export interface TestService<Context = unknown> {
   Foo: (
     fooRequest: FooRequest,
     context: Context
@@ -37999,9 +37999,7 @@ export interface TestServiceService<Context = unknown> {
   ) => Promise<BarResponse> | BarResponse;
 }
 
-export function createTestServiceHandler<Context>(
-  service: TestServiceService<Context>
-) {
+export function createTestService<Context>(service: TestService<Context>) {
   return {
     name: \\"protobuf_unittest.TestService\\",
     methods: {
@@ -58795,14 +58793,14 @@ export async function BarJSON(
 }
 
 //========================================//
-//              Foo Service               //
+//                  Foo                   //
 //========================================//
 
-export interface FooService<Context = unknown> {
+export interface Foo<Context = unknown> {
   Bar: (empty: Empty, context: Context) => Promise<Empty> | Empty;
 }
 
-export function createFooHandler<Context>(service: FooService<Context>) {
+export function createFoo<Context>(service: Foo<Context>) {
   return {
     name: \\"Foo\\",
     methods: {
@@ -59234,10 +59232,10 @@ export async function BarJSON(
 }
 
 //========================================//
-//          TestService Service           //
+//              TestService               //
 //========================================//
 
-export interface TestServiceService<Context = unknown> {
+export interface TestService<Context = unknown> {
   Foo: (
     fooRequest: FooRequest,
     context: Context
@@ -59248,9 +59246,7 @@ export interface TestServiceService<Context = unknown> {
   ) => Promise<BarResponse> | BarResponse;
 }
 
-export function createTestServiceHandler<Context>(
-  service: TestServiceService<Context>
-) {
+export function createTestService<Context>(service: TestService<Context>) {
   return {
     name: \\"protobuf_unittest.TestService\\",
     methods: {
@@ -80072,14 +80068,14 @@ export async function BarJSON(
 }
 
 //========================================//
-//              Foo Service               //
+//                  Foo                   //
 //========================================//
 
-export interface FooService<Context = unknown> {
+export interface Foo<Context = unknown> {
   Bar: (empty: Empty, context: Context) => Promise<Empty> | Empty;
 }
 
-export function createFooHandler<Context>(service: FooService<Context>) {
+export function createFoo<Context>(service: Foo<Context>) {
   return {
     name: \\"Foo\\",
     methods: {


### PR DESCRIPTION
Removes 'Service' suffix from generated service types. Removes 'Handler'
suffix from 'create<Service>' helper.

This is a breaking change.

This enables better out of the box integration with `buf` which expects
service names to end with the Serice suffix. When following that
recommendation, TwirpScript would generate 'FooServiceService'.

Fixes #104