### PR TITLE
drop 'a' from generated doc strings

### DIFF
--- a/clientcompat/src/clientcompat.pb.ts
+++ b/clientcompat/src/clientcompat.pb.ts
@@ -130,35 +130,35 @@ declare namespace ClientCompatMessage {
 
 export const Empty = {
   /**
-   * Serializes a Empty to protobuf.
+   * Serializes Empty to protobuf.
    */
   encode: function (_msg?: Partial<Empty>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a Empty from protobuf.
+   * Deserializes Empty from protobuf.
    */
   decode: function (_bytes?: ByteSource): Empty {
     return {};
   },
 
   /**
-   * Serializes a Empty to JSON.
+   * Serializes Empty to JSON.
    */
   encodeJSON: function (_msg?: Partial<Empty>): string {
     return "{}";
   },
 
   /**
-   * Deserializes a Empty from JSON.
+   * Deserializes Empty from JSON.
    */
   decodeJSON: function (_json?: string): Empty {
     return {};
   },
 
   /**
-   * Initializes a Empty with all fields set to their default value.
+   * Initializes Empty with all fields set to their default value.
    */
   initialize: function (): Empty {
     return {};
@@ -198,35 +198,35 @@ export const Empty = {
 
 export const Req = {
   /**
-   * Serializes a Req to protobuf.
+   * Serializes Req to protobuf.
    */
   encode: function (msg: Partial<Req>): Uint8Array {
     return Req._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Req from protobuf.
+   * Deserializes Req from protobuf.
    */
   decode: function (bytes: ByteSource): Req {
     return Req._readMessage(Req.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Req to JSON.
+   * Serializes Req to JSON.
    */
   encodeJSON: function (msg: Partial<Req>): string {
     return JSON.stringify(Req._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Req from JSON.
+   * Deserializes Req from JSON.
    */
   decodeJSON: function (json: string): Req {
     return Req._readMessageJSON(Req.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Req with all fields set to their default value.
+   * Initializes Req with all fields set to their default value.
    */
   initialize: function (): Req {
     return {
@@ -292,35 +292,35 @@ export const Req = {
 
 export const Resp = {
   /**
-   * Serializes a Resp to protobuf.
+   * Serializes Resp to protobuf.
    */
   encode: function (msg: Partial<Resp>): Uint8Array {
     return Resp._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Resp from protobuf.
+   * Deserializes Resp from protobuf.
    */
   decode: function (bytes: ByteSource): Resp {
     return Resp._readMessage(Resp.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Resp to JSON.
+   * Serializes Resp to JSON.
    */
   encodeJSON: function (msg: Partial<Resp>): string {
     return JSON.stringify(Resp._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Resp from JSON.
+   * Deserializes Resp from JSON.
    */
   decodeJSON: function (json: string): Resp {
     return Resp._readMessageJSON(Resp.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Resp with all fields set to their default value.
+   * Initializes Resp with all fields set to their default value.
    */
   initialize: function (): Resp {
     return {
@@ -386,7 +386,7 @@ export const Resp = {
 
 export const ClientCompatMessage = {
   /**
-   * Serializes a ClientCompatMessage to protobuf.
+   * Serializes ClientCompatMessage to protobuf.
    */
   encode: function (msg: Partial<ClientCompatMessage>): Uint8Array {
     return ClientCompatMessage._writeMessage(
@@ -396,7 +396,7 @@ export const ClientCompatMessage = {
   },
 
   /**
-   * Deserializes a ClientCompatMessage from protobuf.
+   * Deserializes ClientCompatMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ClientCompatMessage {
     return ClientCompatMessage._readMessage(
@@ -406,14 +406,14 @@ export const ClientCompatMessage = {
   },
 
   /**
-   * Serializes a ClientCompatMessage to JSON.
+   * Serializes ClientCompatMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ClientCompatMessage>): string {
     return JSON.stringify(ClientCompatMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ClientCompatMessage from JSON.
+   * Deserializes ClientCompatMessage from JSON.
    */
   decodeJSON: function (json: string): ClientCompatMessage {
     return ClientCompatMessage._readMessageJSON(
@@ -423,7 +423,7 @@ export const ClientCompatMessage = {
   },
 
   /**
-   * Initializes a ClientCompatMessage with all fields set to their default value.
+   * Initializes ClientCompatMessage with all fields set to their default value.
    */
   initialize: function (): ClientCompatMessage {
     return {

--- a/examples/authentication/src/protos/authentication.pb.ts
+++ b/examples/authentication/src/protos/authentication.pb.ts
@@ -101,14 +101,14 @@ export interface Credentials {
 
 export const CurrentUser = {
   /**
-   * Serializes a CurrentUser to protobuf.
+   * Serializes CurrentUser to protobuf.
    */
   encode: function (msg: Partial<CurrentUser>): Uint8Array {
     return CurrentUser._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a CurrentUser from protobuf.
+   * Deserializes CurrentUser from protobuf.
    */
   decode: function (bytes: ByteSource): CurrentUser {
     return CurrentUser._readMessage(
@@ -118,14 +118,14 @@ export const CurrentUser = {
   },
 
   /**
-   * Serializes a CurrentUser to JSON.
+   * Serializes CurrentUser to JSON.
    */
   encodeJSON: function (msg: Partial<CurrentUser>): string {
     return JSON.stringify(CurrentUser._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a CurrentUser from JSON.
+   * Deserializes CurrentUser from JSON.
    */
   decodeJSON: function (json: string): CurrentUser {
     return CurrentUser._readMessageJSON(
@@ -135,7 +135,7 @@ export const CurrentUser = {
   },
 
   /**
-   * Initializes a CurrentUser with all fields set to their default value.
+   * Initializes CurrentUser with all fields set to their default value.
    */
   initialize: function (): CurrentUser {
     return {
@@ -218,14 +218,14 @@ export const CurrentUser = {
 
 export const Credentials = {
   /**
-   * Serializes a Credentials to protobuf.
+   * Serializes Credentials to protobuf.
    */
   encode: function (msg: Partial<Credentials>): Uint8Array {
     return Credentials._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Credentials from protobuf.
+   * Deserializes Credentials from protobuf.
    */
   decode: function (bytes: ByteSource): Credentials {
     return Credentials._readMessage(
@@ -235,14 +235,14 @@ export const Credentials = {
   },
 
   /**
-   * Serializes a Credentials to JSON.
+   * Serializes Credentials to JSON.
    */
   encodeJSON: function (msg: Partial<Credentials>): string {
     return JSON.stringify(Credentials._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Credentials from JSON.
+   * Deserializes Credentials from JSON.
    */
   decodeJSON: function (json: string): Credentials {
     return Credentials._readMessageJSON(
@@ -252,7 +252,7 @@ export const Credentials = {
   },
 
   /**
-   * Initializes a Credentials with all fields set to their default value.
+   * Initializes Credentials with all fields set to their default value.
    */
   initialize: function (): Credentials {
     return {

--- a/examples/authentication/src/protos/haberdasher.pb.ts
+++ b/examples/authentication/src/protos/haberdasher.pb.ts
@@ -110,35 +110,35 @@ export interface Hat {
 
 export const Size = {
   /**
-   * Serializes a Size to protobuf.
+   * Serializes Size to protobuf.
    */
   encode: function (msg: Partial<Size>): Uint8Array {
     return Size._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Size from protobuf.
+   * Deserializes Size from protobuf.
    */
   decode: function (bytes: ByteSource): Size {
     return Size._readMessage(Size.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Size to JSON.
+   * Serializes Size to JSON.
    */
   encodeJSON: function (msg: Partial<Size>): string {
     return JSON.stringify(Size._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Size from JSON.
+   * Deserializes Size from JSON.
    */
   decodeJSON: function (json: string): Size {
     return Size._readMessageJSON(Size.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Size with all fields set to their default value.
+   * Initializes Size with all fields set to their default value.
    */
   initialize: function (): Size {
     return {
@@ -204,35 +204,35 @@ export const Size = {
 
 export const Hat = {
   /**
-   * Serializes a Hat to protobuf.
+   * Serializes Hat to protobuf.
    */
   encode: function (msg: Partial<Hat>): Uint8Array {
     return Hat._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Hat from protobuf.
+   * Deserializes Hat from protobuf.
    */
   decode: function (bytes: ByteSource): Hat {
     return Hat._readMessage(Hat.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Hat to JSON.
+   * Serializes Hat to JSON.
    */
   encodeJSON: function (msg: Partial<Hat>): string {
     return JSON.stringify(Hat._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Hat from JSON.
+   * Deserializes Hat from JSON.
    */
   decodeJSON: function (json: string): Hat {
     return Hat._readMessageJSON(Hat.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Hat with all fields set to their default value.
+   * Initializes Hat with all fields set to their default value.
    */
   initialize: function (): Hat {
     return {

--- a/examples/aws-lambda/src/haberdasher.pb.ts
+++ b/examples/aws-lambda/src/haberdasher.pb.ts
@@ -110,35 +110,35 @@ export interface Hat {
 
 export const Size = {
   /**
-   * Serializes a Size to protobuf.
+   * Serializes Size to protobuf.
    */
   encode: function (msg: Partial<Size>): Uint8Array {
     return Size._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Size from protobuf.
+   * Deserializes Size from protobuf.
    */
   decode: function (bytes: ByteSource): Size {
     return Size._readMessage(Size.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Size to JSON.
+   * Serializes Size to JSON.
    */
   encodeJSON: function (msg: Partial<Size>): string {
     return JSON.stringify(Size._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Size from JSON.
+   * Deserializes Size from JSON.
    */
   decodeJSON: function (json: string): Size {
     return Size._readMessageJSON(Size.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Size with all fields set to their default value.
+   * Initializes Size with all fields set to their default value.
    */
   initialize: function (): Size {
     return {
@@ -204,35 +204,35 @@ export const Size = {
 
 export const Hat = {
   /**
-   * Serializes a Hat to protobuf.
+   * Serializes Hat to protobuf.
    */
   encode: function (msg: Partial<Hat>): Uint8Array {
     return Hat._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Hat from protobuf.
+   * Deserializes Hat from protobuf.
    */
   decode: function (bytes: ByteSource): Hat {
     return Hat._readMessage(Hat.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Hat to JSON.
+   * Serializes Hat to JSON.
    */
   encodeJSON: function (msg: Partial<Hat>): string {
     return JSON.stringify(Hat._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Hat from JSON.
+   * Deserializes Hat from JSON.
    */
   decodeJSON: function (json: string): Hat {
     return Hat._readMessageJSON(Hat.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Hat with all fields set to their default value.
+   * Initializes Hat with all fields set to their default value.
    */
   initialize: function (): Hat {
     return {

--- a/examples/buf/A.pb.ts
+++ b/examples/buf/A.pb.ts
@@ -18,35 +18,35 @@ export interface Foo {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {

--- a/examples/buf/B.pb.ts
+++ b/examples/buf/B.pb.ts
@@ -20,35 +20,35 @@ export interface Bar {
 
 export const Bar = {
   /**
-   * Serializes a Bar to protobuf.
+   * Serializes Bar to protobuf.
    */
   encode: function (msg: Partial<Bar>): Uint8Array {
     return Bar._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Bar from protobuf.
+   * Deserializes Bar from protobuf.
    */
   decode: function (bytes: ByteSource): Bar {
     return Bar._readMessage(Bar.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Bar to JSON.
+   * Serializes Bar to JSON.
    */
   encodeJSON: function (msg: Partial<Bar>): string {
     return JSON.stringify(Bar._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Bar from JSON.
+   * Deserializes Bar from JSON.
    */
   decodeJSON: function (json: string): Bar {
     return Bar._readMessageJSON(Bar.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Bar with all fields set to their default value.
+   * Initializes Bar with all fields set to their default value.
    */
   initialize: function (): Bar {
     return {

--- a/examples/config-dest/out/A.pb.ts
+++ b/examples/config-dest/out/A.pb.ts
@@ -18,35 +18,35 @@ export interface Foo {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {

--- a/examples/config-dest/out/B.pb.ts
+++ b/examples/config-dest/out/B.pb.ts
@@ -20,35 +20,35 @@ export interface Bar {
 
 export const Bar = {
   /**
-   * Serializes a Bar to protobuf.
+   * Serializes Bar to protobuf.
    */
   encode: function (msg: Partial<Bar>): Uint8Array {
     return Bar._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Bar from protobuf.
+   * Deserializes Bar from protobuf.
    */
   decode: function (bytes: ByteSource): Bar {
     return Bar._readMessage(Bar.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Bar to JSON.
+   * Serializes Bar to JSON.
    */
   encodeJSON: function (msg: Partial<Bar>): string {
     return JSON.stringify(Bar._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Bar from JSON.
+   * Deserializes Bar from JSON.
    */
   decodeJSON: function (json: string): Bar {
     return Bar._readMessageJSON(Bar.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Bar with all fields set to their default value.
+   * Initializes Bar with all fields set to their default value.
    */
   initialize: function (): Bar {
     return {

--- a/examples/config-exclude/src/foo/A.pb.ts
+++ b/examples/config-exclude/src/foo/A.pb.ts
@@ -18,35 +18,35 @@ export interface Foo {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {

--- a/examples/config-json/src/A.pb.ts
+++ b/examples/config-json/src/A.pb.ts
@@ -19,35 +19,35 @@ export interface Foo {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {

--- a/examples/config-root/src/A.pb.ts
+++ b/examples/config-root/src/A.pb.ts
@@ -18,35 +18,35 @@ export interface Foo {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {

--- a/examples/config-root/src/B.pb.ts
+++ b/examples/config-root/src/B.pb.ts
@@ -20,35 +20,35 @@ export interface Bar {
 
 export const Bar = {
   /**
-   * Serializes a Bar to protobuf.
+   * Serializes Bar to protobuf.
    */
   encode: function (msg: Partial<Bar>): Uint8Array {
     return Bar._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Bar from protobuf.
+   * Deserializes Bar from protobuf.
    */
   decode: function (bytes: ByteSource): Bar {
     return Bar._readMessage(Bar.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Bar to JSON.
+   * Serializes Bar to JSON.
    */
   encodeJSON: function (msg: Partial<Bar>): string {
     return JSON.stringify(Bar._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Bar from JSON.
+   * Deserializes Bar from JSON.
    */
   decodeJSON: function (json: string): Bar {
     return Bar._readMessageJSON(Bar.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Bar with all fields set to their default value.
+   * Initializes Bar with all fields set to their default value.
    */
   initialize: function (): Bar {
     return {

--- a/examples/javascript-fullstack/src/protos/haberdasher.pb.js
+++ b/examples/javascript-fullstack/src/protos/haberdasher.pb.js
@@ -60,35 +60,35 @@ export function createHaberdasher(service) {
 
 export const Size = {
   /**
-   * Serializes a Size to protobuf.
+   * Serializes Size to protobuf.
    */
   encode: function (msg) {
     return Size._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Size from protobuf.
+   * Deserializes Size from protobuf.
    */
   decode: function (bytes) {
     return Size._readMessage(Size.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Size to JSON.
+   * Serializes Size to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Size._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Size from JSON.
+   * Deserializes Size from JSON.
    */
   decodeJSON: function (json) {
     return Size._readMessageJSON(Size.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Size with all fields set to their default value.
+   * Initializes Size with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -151,35 +151,35 @@ export const Size = {
 
 export const Hat = {
   /**
-   * Serializes a Hat to protobuf.
+   * Serializes Hat to protobuf.
    */
   encode: function (msg) {
     return Hat._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Hat from protobuf.
+   * Deserializes Hat from protobuf.
    */
   decode: function (bytes) {
     return Hat._readMessage(Hat.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Hat to JSON.
+   * Serializes Hat to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Hat._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Hat from JSON.
+   * Deserializes Hat from JSON.
    */
   decodeJSON: function (json) {
     return Hat._readMessageJSON(Hat.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Hat with all fields set to their default value.
+   * Initializes Hat with all fields set to their default value.
    */
   initialize: function () {
     return {

--- a/examples/server-to-server/src/protos/haberdasher.pb.ts
+++ b/examples/server-to-server/src/protos/haberdasher.pb.ts
@@ -110,35 +110,35 @@ export interface Hat {
 
 export const Size = {
   /**
-   * Serializes a Size to protobuf.
+   * Serializes Size to protobuf.
    */
   encode: function (msg: Partial<Size>): Uint8Array {
     return Size._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Size from protobuf.
+   * Deserializes Size from protobuf.
    */
   decode: function (bytes: ByteSource): Size {
     return Size._readMessage(Size.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Size to JSON.
+   * Serializes Size to JSON.
    */
   encodeJSON: function (msg: Partial<Size>): string {
     return JSON.stringify(Size._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Size from JSON.
+   * Deserializes Size from JSON.
    */
   decodeJSON: function (json: string): Size {
     return Size._readMessageJSON(Size.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Size with all fields set to their default value.
+   * Initializes Size with all fields set to their default value.
    */
   initialize: function (): Size {
     return {
@@ -204,35 +204,35 @@ export const Size = {
 
 export const Hat = {
   /**
-   * Serializes a Hat to protobuf.
+   * Serializes Hat to protobuf.
    */
   encode: function (msg: Partial<Hat>): Uint8Array {
     return Hat._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Hat from protobuf.
+   * Deserializes Hat from protobuf.
    */
   decode: function (bytes: ByteSource): Hat {
     return Hat._readMessage(Hat.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Hat to JSON.
+   * Serializes Hat to JSON.
    */
   encodeJSON: function (msg: Partial<Hat>): string {
     return JSON.stringify(Hat._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Hat from JSON.
+   * Deserializes Hat from JSON.
    */
   decodeJSON: function (json: string): Hat {
     return Hat._readMessageJSON(Hat.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Hat with all fields set to their default value.
+   * Initializes Hat with all fields set to their default value.
    */
   initialize: function (): Hat {
     return {

--- a/examples/typescript-fullstack/src/protos/haberdasher.pb.ts
+++ b/examples/typescript-fullstack/src/protos/haberdasher.pb.ts
@@ -110,35 +110,35 @@ export interface Hat {
 
 export const Size = {
   /**
-   * Serializes a Size to protobuf.
+   * Serializes Size to protobuf.
    */
   encode: function (msg: Partial<Size>): Uint8Array {
     return Size._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Size from protobuf.
+   * Deserializes Size from protobuf.
    */
   decode: function (bytes: ByteSource): Size {
     return Size._readMessage(Size.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Size to JSON.
+   * Serializes Size to JSON.
    */
   encodeJSON: function (msg: Partial<Size>): string {
     return JSON.stringify(Size._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Size from JSON.
+   * Deserializes Size from JSON.
    */
   decodeJSON: function (json: string): Size {
     return Size._readMessageJSON(Size.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Size with all fields set to their default value.
+   * Initializes Size with all fields set to their default value.
    */
   initialize: function (): Size {
     return {
@@ -204,35 +204,35 @@ export const Size = {
 
 export const Hat = {
   /**
-   * Serializes a Hat to protobuf.
+   * Serializes Hat to protobuf.
    */
   encode: function (msg: Partial<Hat>): Uint8Array {
     return Hat._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Hat from protobuf.
+   * Deserializes Hat from protobuf.
    */
   decode: function (bytes: ByteSource): Hat {
     return Hat._readMessage(Hat.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Hat to JSON.
+   * Serializes Hat to JSON.
    */
   encodeJSON: function (msg: Partial<Hat>): string {
     return JSON.stringify(Hat._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Hat from JSON.
+   * Deserializes Hat from JSON.
    */
   decodeJSON: function (json: string): Hat {
     return Hat._readMessageJSON(Hat.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Hat with all fields set to their default value.
+   * Initializes Hat with all fields set to their default value.
    */
   initialize: function (): Hat {
     return {

--- a/src/autogenerate/index.ts
+++ b/src/autogenerate/index.ts
@@ -87,7 +87,7 @@ function writeSerializers(types: ProtoTypes[], isTopLevel: boolean): string {
           // encode (protobuf)
           result += `\
           /**
-           * Serializes a ${node.content.fullyQualifiedName} to protobuf.
+           * Serializes ${node.content.fullyQualifiedName} to protobuf.
            */
             `;
           if (isEmpty) {
@@ -108,7 +108,7 @@ function writeSerializers(types: ProtoTypes[], isTopLevel: boolean): string {
           // decode (protobuf)
           result += `\
           /**
-           * Deserializes a ${node.content.fullyQualifiedName} from protobuf.
+           * Deserializes ${node.content.fullyQualifiedName} from protobuf.
            */
           `;
           if (isEmpty) {
@@ -129,7 +129,7 @@ function writeSerializers(types: ProtoTypes[], isTopLevel: boolean): string {
           // encode (json)
           result += `\
           /**
-           * Serializes a ${node.content.fullyQualifiedName} to JSON.
+           * Serializes ${node.content.fullyQualifiedName} to JSON.
            */
           `;
           if (isEmpty) {
@@ -150,7 +150,7 @@ function writeSerializers(types: ProtoTypes[], isTopLevel: boolean): string {
           // decode (json)
           result += `\
       /**
-       * Deserializes a ${node.content.fullyQualifiedName} from JSON.
+       * Deserializes ${node.content.fullyQualifiedName} from JSON.
        */
       `;
           if (isEmpty) {
@@ -171,7 +171,7 @@ function writeSerializers(types: ProtoTypes[], isTopLevel: boolean): string {
           // initialize
           result += `\
           /**
-           * Initializes a ${
+           * Initializes ${
              node.content.fullyQualifiedName
            } with all fields set to their default value.
            */

--- a/src/test-protos/__snapshots__/test.ts.snap
+++ b/src/test-protos/__snapshots__/test.ts.snap
@@ -44,7 +44,7 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const PublicImportMessage = {
   /**
-   * Serializes a PublicImportMessage to protobuf.
+   * Serializes PublicImportMessage to protobuf.
    */
   encode: function (msg) {
     return PublicImportMessage._writeMessage(
@@ -54,7 +54,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Deserializes a PublicImportMessage from protobuf.
+   * Deserializes PublicImportMessage from protobuf.
    */
   decode: function (bytes) {
     return PublicImportMessage._readMessage(
@@ -64,14 +64,14 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Serializes a PublicImportMessage to JSON.
+   * Serializes PublicImportMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(PublicImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a PublicImportMessage from JSON.
+   * Deserializes PublicImportMessage from JSON.
    */
   decodeJSON: function (json) {
     return PublicImportMessage._readMessageJSON(
@@ -81,7 +81,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Initializes a PublicImportMessage with all fields set to their default value.
+   * Initializes PublicImportMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -261,7 +261,7 @@ export const ImportEnumForMap = {
 
 export const ImportMessage = {
   /**
-   * Serializes a ImportMessage to protobuf.
+   * Serializes ImportMessage to protobuf.
    */
   encode: function (msg) {
     return ImportMessage._writeMessage(
@@ -271,7 +271,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Deserializes a ImportMessage from protobuf.
+   * Deserializes ImportMessage from protobuf.
    */
   decode: function (bytes) {
     return ImportMessage._readMessage(
@@ -281,14 +281,14 @@ export const ImportMessage = {
   },
 
   /**
-   * Serializes a ImportMessage to JSON.
+   * Serializes ImportMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ImportMessage from JSON.
+   * Deserializes ImportMessage from JSON.
    */
   decodeJSON: function (json) {
     return ImportMessage._readMessageJSON(
@@ -298,7 +298,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Initializes a ImportMessage with all fields set to their default value.
+   * Initializes ImportMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -1376,7 +1376,7 @@ export const VeryLargeEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg) {
     return TestAllTypes._writeMessage(
@@ -1386,7 +1386,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return TestAllTypes._readMessage(
@@ -1396,14 +1396,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestAllTypes._readMessageJSON(
@@ -1413,7 +1413,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -2812,7 +2812,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -2822,7 +2822,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.NestedMessage._readMessage(
@@ -2832,14 +2832,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -2849,7 +2849,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -2912,7 +2912,7 @@ export const TestAllTypes = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestAllTypes.OptionalGroup to protobuf.
+     * Serializes TestAllTypes.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.OptionalGroup._writeMessage(
@@ -2922,7 +2922,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from protobuf.
+     * Deserializes TestAllTypes.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.OptionalGroup._readMessage(
@@ -2932,14 +2932,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.OptionalGroup to JSON.
+     * Serializes TestAllTypes.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from JSON.
+     * Deserializes TestAllTypes.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.OptionalGroup._readMessageJSON(
@@ -2949,7 +2949,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.OptionalGroup with all fields set to their default value.
+     * Initializes TestAllTypes.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -3012,7 +3012,7 @@ export const TestAllTypes = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to protobuf.
+     * Serializes TestAllTypes.RepeatedGroup to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.RepeatedGroup._writeMessage(
@@ -3022,7 +3022,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from protobuf.
+     * Deserializes TestAllTypes.RepeatedGroup from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.RepeatedGroup._readMessage(
@@ -3032,14 +3032,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to JSON.
+     * Serializes TestAllTypes.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.RepeatedGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from JSON.
+     * Deserializes TestAllTypes.RepeatedGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.RepeatedGroup._readMessageJSON(
@@ -3049,7 +3049,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.RepeatedGroup with all fields set to their default value.
+     * Initializes TestAllTypes.RepeatedGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -3113,7 +3113,7 @@ export const TestAllTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg) {
     return NestedTestAllTypes._writeMessage(
@@ -3123,7 +3123,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return NestedTestAllTypes._readMessage(
@@ -3133,14 +3133,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return NestedTestAllTypes._readMessageJSON(
@@ -3150,7 +3150,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3265,7 +3265,7 @@ export const NestedTestAllTypes = {
 
 export const TestDeprecatedFields = {
   /**
-   * Serializes a TestDeprecatedFields to protobuf.
+   * Serializes TestDeprecatedFields to protobuf.
    */
   encode: function (msg) {
     return TestDeprecatedFields._writeMessage(
@@ -3275,7 +3275,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from protobuf.
+   * Deserializes TestDeprecatedFields from protobuf.
    */
   decode: function (bytes) {
     return TestDeprecatedFields._readMessage(
@@ -3285,14 +3285,14 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Serializes a TestDeprecatedFields to JSON.
+   * Serializes TestDeprecatedFields to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDeprecatedFields._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from JSON.
+   * Deserializes TestDeprecatedFields from JSON.
    */
   decodeJSON: function (json) {
     return TestDeprecatedFields._readMessageJSON(
@@ -3302,7 +3302,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Initializes a TestDeprecatedFields with all fields set to their default value.
+   * Initializes TestDeprecatedFields with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3380,35 +3380,35 @@ export const TestDeprecatedFields = {
 
 export const TestDeprecatedMessage = {
   /**
-   * Serializes a TestDeprecatedMessage to protobuf.
+   * Serializes TestDeprecatedMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from protobuf.
+   * Deserializes TestDeprecatedMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestDeprecatedMessage to JSON.
+   * Serializes TestDeprecatedMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from JSON.
+   * Deserializes TestDeprecatedMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestDeprecatedMessage with all fields set to their default value.
+   * Initializes TestDeprecatedMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -3445,7 +3445,7 @@ export const TestDeprecatedMessage = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg) {
     return ForeignMessage._writeMessage(
@@ -3455,7 +3455,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes) {
     return ForeignMessage._readMessage(
@@ -3465,14 +3465,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json) {
     return ForeignMessage._readMessageJSON(
@@ -3482,7 +3482,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3560,35 +3560,35 @@ export const ForeignMessage = {
 
 export const TestReservedFields = {
   /**
-   * Serializes a TestReservedFields to protobuf.
+   * Serializes TestReservedFields to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestReservedFields from protobuf.
+   * Deserializes TestReservedFields from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestReservedFields to JSON.
+   * Serializes TestReservedFields to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestReservedFields from JSON.
+   * Deserializes TestReservedFields from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestReservedFields with all fields set to their default value.
+   * Initializes TestReservedFields with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -3625,35 +3625,35 @@ export const TestReservedFields = {
 
 export const TestAllExtensions = {
   /**
-   * Serializes a TestAllExtensions to protobuf.
+   * Serializes TestAllExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestAllExtensions from protobuf.
+   * Deserializes TestAllExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestAllExtensions to JSON.
+   * Serializes TestAllExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestAllExtensions from JSON.
+   * Deserializes TestAllExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestAllExtensions with all fields set to their default value.
+   * Initializes TestAllExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -3690,7 +3690,7 @@ export const TestAllExtensions = {
 
 export const OptionalGroup_extension = {
   /**
-   * Serializes a OptionalGroup_extension to protobuf.
+   * Serializes OptionalGroup_extension to protobuf.
    */
   encode: function (msg) {
     return OptionalGroup_extension._writeMessage(
@@ -3700,7 +3700,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from protobuf.
+   * Deserializes OptionalGroup_extension from protobuf.
    */
   decode: function (bytes) {
     return OptionalGroup_extension._readMessage(
@@ -3710,14 +3710,14 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Serializes a OptionalGroup_extension to JSON.
+   * Serializes OptionalGroup_extension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OptionalGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from JSON.
+   * Deserializes OptionalGroup_extension from JSON.
    */
   decodeJSON: function (json) {
     return OptionalGroup_extension._readMessageJSON(
@@ -3727,7 +3727,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Initializes a OptionalGroup_extension with all fields set to their default value.
+   * Initializes OptionalGroup_extension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3790,7 +3790,7 @@ export const OptionalGroup_extension = {
 
 export const RepeatedGroup_extension = {
   /**
-   * Serializes a RepeatedGroup_extension to protobuf.
+   * Serializes RepeatedGroup_extension to protobuf.
    */
   encode: function (msg) {
     return RepeatedGroup_extension._writeMessage(
@@ -3800,7 +3800,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from protobuf.
+   * Deserializes RepeatedGroup_extension from protobuf.
    */
   decode: function (bytes) {
     return RepeatedGroup_extension._readMessage(
@@ -3810,14 +3810,14 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Serializes a RepeatedGroup_extension to JSON.
+   * Serializes RepeatedGroup_extension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(RepeatedGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from JSON.
+   * Deserializes RepeatedGroup_extension from JSON.
    */
   decodeJSON: function (json) {
     return RepeatedGroup_extension._readMessageJSON(
@@ -3827,7 +3827,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Initializes a RepeatedGroup_extension with all fields set to their default value.
+   * Initializes RepeatedGroup_extension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3890,14 +3890,14 @@ export const RepeatedGroup_extension = {
 
 export const TestGroup = {
   /**
-   * Serializes a TestGroup to protobuf.
+   * Serializes TestGroup to protobuf.
    */
   encode: function (msg) {
     return TestGroup._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestGroup from protobuf.
+   * Deserializes TestGroup from protobuf.
    */
   decode: function (bytes) {
     return TestGroup._readMessage(
@@ -3907,21 +3907,21 @@ export const TestGroup = {
   },
 
   /**
-   * Serializes a TestGroup to JSON.
+   * Serializes TestGroup to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestGroup._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestGroup from JSON.
+   * Deserializes TestGroup from JSON.
    */
   decodeJSON: function (json) {
     return TestGroup._readMessageJSON(TestGroup.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestGroup with all fields set to their default value.
+   * Initializes TestGroup with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -3990,7 +3990,7 @@ export const TestGroup = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestGroup.OptionalGroup to protobuf.
+     * Serializes TestGroup.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestGroup.OptionalGroup._writeMessage(
@@ -4000,7 +4000,7 @@ export const TestGroup = {
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from protobuf.
+     * Deserializes TestGroup.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestGroup.OptionalGroup._readMessage(
@@ -4010,14 +4010,14 @@ export const TestGroup = {
     },
 
     /**
-     * Serializes a TestGroup.OptionalGroup to JSON.
+     * Serializes TestGroup.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestGroup.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from JSON.
+     * Deserializes TestGroup.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestGroup.OptionalGroup._readMessageJSON(
@@ -4027,7 +4027,7 @@ export const TestGroup = {
     },
 
     /**
-     * Initializes a TestGroup.OptionalGroup with all fields set to their default value.
+     * Initializes TestGroup.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -4091,35 +4091,35 @@ export const TestGroup = {
 
 export const TestGroupExtension = {
   /**
-   * Serializes a TestGroupExtension to protobuf.
+   * Serializes TestGroupExtension to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestGroupExtension from protobuf.
+   * Deserializes TestGroupExtension from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestGroupExtension to JSON.
+   * Serializes TestGroupExtension to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestGroupExtension from JSON.
+   * Deserializes TestGroupExtension from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestGroupExtension with all fields set to their default value.
+   * Initializes TestGroupExtension with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -4156,35 +4156,35 @@ export const TestGroupExtension = {
 
 export const TestNestedExtension = {
   /**
-   * Serializes a TestNestedExtension to protobuf.
+   * Serializes TestNestedExtension to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestNestedExtension from protobuf.
+   * Deserializes TestNestedExtension from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestNestedExtension to JSON.
+   * Serializes TestNestedExtension to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestNestedExtension from JSON.
+   * Deserializes TestNestedExtension from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestNestedExtension with all fields set to their default value.
+   * Initializes TestNestedExtension with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -4220,7 +4220,7 @@ export const TestNestedExtension = {
 
   OptionalGroup_extension: {
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to protobuf.
+     * Serializes TestNestedExtension.OptionalGroup_extension to protobuf.
      */
     encode: function (msg) {
       return TestNestedExtension.OptionalGroup_extension._writeMessage(
@@ -4230,7 +4230,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from protobuf.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from protobuf.
      */
     decode: function (bytes) {
       return TestNestedExtension.OptionalGroup_extension._readMessage(
@@ -4240,7 +4240,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to JSON.
+     * Serializes TestNestedExtension.OptionalGroup_extension to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -4249,7 +4249,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from JSON.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from JSON.
      */
     decodeJSON: function (json) {
       return TestNestedExtension.OptionalGroup_extension._readMessageJSON(
@@ -4259,7 +4259,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Initializes a TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
+     * Initializes TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -4323,7 +4323,7 @@ export const TestNestedExtension = {
 
 export const TestChildExtension = {
   /**
-   * Serializes a TestChildExtension to protobuf.
+   * Serializes TestChildExtension to protobuf.
    */
   encode: function (msg) {
     return TestChildExtension._writeMessage(
@@ -4333,7 +4333,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Deserializes a TestChildExtension from protobuf.
+   * Deserializes TestChildExtension from protobuf.
    */
   decode: function (bytes) {
     return TestChildExtension._readMessage(
@@ -4343,14 +4343,14 @@ export const TestChildExtension = {
   },
 
   /**
-   * Serializes a TestChildExtension to JSON.
+   * Serializes TestChildExtension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestChildExtension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestChildExtension from JSON.
+   * Deserializes TestChildExtension from JSON.
    */
   decodeJSON: function (json) {
     return TestChildExtension._readMessageJSON(
@@ -4360,7 +4360,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Initializes a TestChildExtension with all fields set to their default value.
+   * Initializes TestChildExtension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -4468,7 +4468,7 @@ export const TestChildExtension = {
 
 export const TestRequired = {
   /**
-   * Serializes a TestRequired to protobuf.
+   * Serializes TestRequired to protobuf.
    */
   encode: function (msg) {
     return TestRequired._writeMessage(
@@ -4478,7 +4478,7 @@ export const TestRequired = {
   },
 
   /**
-   * Deserializes a TestRequired from protobuf.
+   * Deserializes TestRequired from protobuf.
    */
   decode: function (bytes) {
     return TestRequired._readMessage(
@@ -4488,14 +4488,14 @@ export const TestRequired = {
   },
 
   /**
-   * Serializes a TestRequired to JSON.
+   * Serializes TestRequired to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequired._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequired from JSON.
+   * Deserializes TestRequired from JSON.
    */
   decodeJSON: function (json) {
     return TestRequired._readMessageJSON(
@@ -4505,7 +4505,7 @@ export const TestRequired = {
   },
 
   /**
-   * Initializes a TestRequired with all fields set to their default value.
+   * Initializes TestRequired with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -5048,7 +5048,7 @@ export const TestRequired = {
 
 export const TestRequiredForeign = {
   /**
-   * Serializes a TestRequiredForeign to protobuf.
+   * Serializes TestRequiredForeign to protobuf.
    */
   encode: function (msg) {
     return TestRequiredForeign._writeMessage(
@@ -5058,7 +5058,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Deserializes a TestRequiredForeign from protobuf.
+   * Deserializes TestRequiredForeign from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredForeign._readMessage(
@@ -5068,14 +5068,14 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Serializes a TestRequiredForeign to JSON.
+   * Serializes TestRequiredForeign to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredForeign._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredForeign from JSON.
+   * Deserializes TestRequiredForeign from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredForeign._readMessageJSON(
@@ -5085,7 +5085,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Initializes a TestRequiredForeign with all fields set to their default value.
+   * Initializes TestRequiredForeign with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -5197,7 +5197,7 @@ export const TestRequiredForeign = {
 
 export const TestRequiredMessage = {
   /**
-   * Serializes a TestRequiredMessage to protobuf.
+   * Serializes TestRequiredMessage to protobuf.
    */
   encode: function (msg) {
     return TestRequiredMessage._writeMessage(
@@ -5207,7 +5207,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Deserializes a TestRequiredMessage from protobuf.
+   * Deserializes TestRequiredMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredMessage._readMessage(
@@ -5217,14 +5217,14 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Serializes a TestRequiredMessage to JSON.
+   * Serializes TestRequiredMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessage from JSON.
+   * Deserializes TestRequiredMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredMessage._readMessageJSON(
@@ -5234,7 +5234,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Initializes a TestRequiredMessage with all fields set to their default value.
+   * Initializes TestRequiredMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -5353,7 +5353,7 @@ export const TestRequiredMessage = {
 
 export const TestForeignNested = {
   /**
-   * Serializes a TestForeignNested to protobuf.
+   * Serializes TestForeignNested to protobuf.
    */
   encode: function (msg) {
     return TestForeignNested._writeMessage(
@@ -5363,7 +5363,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Deserializes a TestForeignNested from protobuf.
+   * Deserializes TestForeignNested from protobuf.
    */
   decode: function (bytes) {
     return TestForeignNested._readMessage(
@@ -5373,14 +5373,14 @@ export const TestForeignNested = {
   },
 
   /**
-   * Serializes a TestForeignNested to JSON.
+   * Serializes TestForeignNested to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestForeignNested._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestForeignNested from JSON.
+   * Deserializes TestForeignNested from JSON.
    */
   decodeJSON: function (json) {
     return TestForeignNested._readMessageJSON(
@@ -5390,7 +5390,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Initializes a TestForeignNested with all fields set to their default value.
+   * Initializes TestForeignNested with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -5467,35 +5467,35 @@ export const TestForeignNested = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -5532,35 +5532,35 @@ export const TestEmptyMessage = {
 
 export const TestEmptyMessageWithExtensions = {
   /**
-   * Serializes a TestEmptyMessageWithExtensions to protobuf.
+   * Serializes TestEmptyMessageWithExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from protobuf.
+   * Deserializes TestEmptyMessageWithExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessageWithExtensions to JSON.
+   * Serializes TestEmptyMessageWithExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from JSON.
+   * Deserializes TestEmptyMessageWithExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessageWithExtensions with all fields set to their default value.
+   * Initializes TestEmptyMessageWithExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -5597,35 +5597,35 @@ export const TestEmptyMessageWithExtensions = {
 
 export const TestPickleNestedMessage = {
   /**
-   * Serializes a TestPickleNestedMessage to protobuf.
+   * Serializes TestPickleNestedMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from protobuf.
+   * Deserializes TestPickleNestedMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestPickleNestedMessage to JSON.
+   * Serializes TestPickleNestedMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from JSON.
+   * Deserializes TestPickleNestedMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestPickleNestedMessage with all fields set to their default value.
+   * Initializes TestPickleNestedMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -5661,7 +5661,7 @@ export const TestPickleNestedMessage = {
 
   NestedMessage: {
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to protobuf.
+     * Serializes TestPickleNestedMessage.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestPickleNestedMessage.NestedMessage._writeMessage(
@@ -5671,7 +5671,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from protobuf.
+     * Deserializes TestPickleNestedMessage.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestPickleNestedMessage.NestedMessage._readMessage(
@@ -5681,7 +5681,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to JSON.
+     * Serializes TestPickleNestedMessage.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -5690,7 +5690,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from JSON.
+     * Deserializes TestPickleNestedMessage.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestPickleNestedMessage.NestedMessage._readMessageJSON(
@@ -5700,7 +5700,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Initializes a TestPickleNestedMessage.NestedMessage with all fields set to their default value.
+     * Initializes TestPickleNestedMessage.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -5762,7 +5762,7 @@ export const TestPickleNestedMessage = {
 
     NestedNestedMessage: {
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
        */
       encode: function (msg) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._writeMessage(
@@ -5772,7 +5772,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
        */
       decode: function (bytes) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._readMessage(
@@ -5782,7 +5782,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -5793,7 +5793,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
        */
       decodeJSON: function (json) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._readMessageJSON(
@@ -5803,7 +5803,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Initializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
+       * Initializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -5868,35 +5868,35 @@ export const TestPickleNestedMessage = {
 
 export const TestMultipleExtensionRanges = {
   /**
-   * Serializes a TestMultipleExtensionRanges to protobuf.
+   * Serializes TestMultipleExtensionRanges to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from protobuf.
+   * Deserializes TestMultipleExtensionRanges from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestMultipleExtensionRanges to JSON.
+   * Serializes TestMultipleExtensionRanges to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from JSON.
+   * Deserializes TestMultipleExtensionRanges from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestMultipleExtensionRanges with all fields set to their default value.
+   * Initializes TestMultipleExtensionRanges with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -5933,7 +5933,7 @@ export const TestMultipleExtensionRanges = {
 
 export const TestReallyLargeTagNumber = {
   /**
-   * Serializes a TestReallyLargeTagNumber to protobuf.
+   * Serializes TestReallyLargeTagNumber to protobuf.
    */
   encode: function (msg) {
     return TestReallyLargeTagNumber._writeMessage(
@@ -5943,7 +5943,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from protobuf.
+   * Deserializes TestReallyLargeTagNumber from protobuf.
    */
   decode: function (bytes) {
     return TestReallyLargeTagNumber._readMessage(
@@ -5953,14 +5953,14 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Serializes a TestReallyLargeTagNumber to JSON.
+   * Serializes TestReallyLargeTagNumber to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestReallyLargeTagNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from JSON.
+   * Deserializes TestReallyLargeTagNumber from JSON.
    */
   decodeJSON: function (json) {
     return TestReallyLargeTagNumber._readMessageJSON(
@@ -5970,7 +5970,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Initializes a TestReallyLargeTagNumber with all fields set to their default value.
+   * Initializes TestReallyLargeTagNumber with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -6048,7 +6048,7 @@ export const TestReallyLargeTagNumber = {
 
 export const TestRecursiveMessage = {
   /**
-   * Serializes a TestRecursiveMessage to protobuf.
+   * Serializes TestRecursiveMessage to protobuf.
    */
   encode: function (msg) {
     return TestRecursiveMessage._writeMessage(
@@ -6058,7 +6058,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from protobuf.
+   * Deserializes TestRecursiveMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRecursiveMessage._readMessage(
@@ -6068,14 +6068,14 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMessage to JSON.
+   * Serializes TestRecursiveMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRecursiveMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from JSON.
+   * Deserializes TestRecursiveMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRecursiveMessage._readMessageJSON(
@@ -6085,7 +6085,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMessage with all fields set to their default value.
+   * Initializes TestRecursiveMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -6168,7 +6168,7 @@ export const TestRecursiveMessage = {
 
 export const TestMutualRecursionA = {
   /**
-   * Serializes a TestMutualRecursionA to protobuf.
+   * Serializes TestMutualRecursionA to protobuf.
    */
   encode: function (msg) {
     return TestMutualRecursionA._writeMessage(
@@ -6178,7 +6178,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from protobuf.
+   * Deserializes TestMutualRecursionA from protobuf.
    */
   decode: function (bytes) {
     return TestMutualRecursionA._readMessage(
@@ -6188,14 +6188,14 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Serializes a TestMutualRecursionA to JSON.
+   * Serializes TestMutualRecursionA to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMutualRecursionA._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from JSON.
+   * Deserializes TestMutualRecursionA from JSON.
    */
   decodeJSON: function (json) {
     return TestMutualRecursionA._readMessageJSON(
@@ -6205,7 +6205,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Initializes a TestMutualRecursionA with all fields set to their default value.
+   * Initializes TestMutualRecursionA with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -6272,7 +6272,7 @@ export const TestMutualRecursionA = {
 
   SubMessage: {
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to protobuf.
+     * Serializes TestMutualRecursionA.SubMessage to protobuf.
      */
     encode: function (msg) {
       return TestMutualRecursionA.SubMessage._writeMessage(
@@ -6282,7 +6282,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from protobuf.
+     * Deserializes TestMutualRecursionA.SubMessage from protobuf.
      */
     decode: function (bytes) {
       return TestMutualRecursionA.SubMessage._readMessage(
@@ -6292,7 +6292,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to JSON.
+     * Serializes TestMutualRecursionA.SubMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -6301,7 +6301,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from JSON.
+     * Deserializes TestMutualRecursionA.SubMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestMutualRecursionA.SubMessage._readMessageJSON(
@@ -6311,7 +6311,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubMessage with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -6379,7 +6379,7 @@ export const TestMutualRecursionA = {
 
   SubGroup: {
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to protobuf.
+     * Serializes TestMutualRecursionA.SubGroup to protobuf.
      */
     encode: function (msg) {
       return TestMutualRecursionA.SubGroup._writeMessage(
@@ -6389,7 +6389,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from protobuf.
+     * Deserializes TestMutualRecursionA.SubGroup from protobuf.
      */
     decode: function (bytes) {
       return TestMutualRecursionA.SubGroup._readMessage(
@@ -6399,7 +6399,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to JSON.
+     * Serializes TestMutualRecursionA.SubGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -6408,7 +6408,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from JSON.
+     * Deserializes TestMutualRecursionA.SubGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestMutualRecursionA.SubGroup._readMessageJSON(
@@ -6418,7 +6418,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubGroup with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -6516,7 +6516,7 @@ export const TestMutualRecursionA = {
 
 export const TestMutualRecursionB = {
   /**
-   * Serializes a TestMutualRecursionB to protobuf.
+   * Serializes TestMutualRecursionB to protobuf.
    */
   encode: function (msg) {
     return TestMutualRecursionB._writeMessage(
@@ -6526,7 +6526,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from protobuf.
+   * Deserializes TestMutualRecursionB from protobuf.
    */
   decode: function (bytes) {
     return TestMutualRecursionB._readMessage(
@@ -6536,14 +6536,14 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Serializes a TestMutualRecursionB to JSON.
+   * Serializes TestMutualRecursionB to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMutualRecursionB._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from JSON.
+   * Deserializes TestMutualRecursionB from JSON.
    */
   decodeJSON: function (json) {
     return TestMutualRecursionB._readMessageJSON(
@@ -6553,7 +6553,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Initializes a TestMutualRecursionB with all fields set to their default value.
+   * Initializes TestMutualRecursionB with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -6636,7 +6636,7 @@ export const TestMutualRecursionB = {
 
 export const TestIsInitialized = {
   /**
-   * Serializes a TestIsInitialized to protobuf.
+   * Serializes TestIsInitialized to protobuf.
    */
   encode: function (msg) {
     return TestIsInitialized._writeMessage(
@@ -6646,7 +6646,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Deserializes a TestIsInitialized from protobuf.
+   * Deserializes TestIsInitialized from protobuf.
    */
   decode: function (bytes) {
     return TestIsInitialized._readMessage(
@@ -6656,14 +6656,14 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Serializes a TestIsInitialized to JSON.
+   * Serializes TestIsInitialized to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestIsInitialized._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestIsInitialized from JSON.
+   * Deserializes TestIsInitialized from JSON.
    */
   decodeJSON: function (json) {
     return TestIsInitialized._readMessageJSON(
@@ -6673,7 +6673,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Initializes a TestIsInitialized with all fields set to their default value.
+   * Initializes TestIsInitialized with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -6749,35 +6749,35 @@ export const TestIsInitialized = {
 
   SubMessage: {
     /**
-     * Serializes a TestIsInitialized.SubMessage to protobuf.
+     * Serializes TestIsInitialized.SubMessage to protobuf.
      */
     encode: function (_msg) {
       return new Uint8Array();
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from protobuf.
+     * Deserializes TestIsInitialized.SubMessage from protobuf.
      */
     decode: function (_bytes) {
       return {};
     },
 
     /**
-     * Serializes a TestIsInitialized.SubMessage to JSON.
+     * Serializes TestIsInitialized.SubMessage to JSON.
      */
     encodeJSON: function (_msg) {
       return \\"{}\\";
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from JSON.
+     * Deserializes TestIsInitialized.SubMessage from JSON.
      */
     decodeJSON: function (_json) {
       return {};
     },
 
     /**
-     * Initializes a TestIsInitialized.SubMessage with all fields set to their default value.
+     * Initializes TestIsInitialized.SubMessage with all fields set to their default value.
      */
     initialize: function () {
       return {};
@@ -6813,7 +6813,7 @@ export const TestIsInitialized = {
 
     SubGroup: {
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to protobuf.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to protobuf.
        */
       encode: function (msg) {
         return TestIsInitialized.SubMessage.SubGroup._writeMessage(
@@ -6823,7 +6823,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from protobuf.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from protobuf.
        */
       decode: function (bytes) {
         return TestIsInitialized.SubMessage.SubGroup._readMessage(
@@ -6833,7 +6833,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to JSON.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -6842,7 +6842,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from JSON.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from JSON.
        */
       decodeJSON: function (json) {
         return TestIsInitialized.SubMessage.SubGroup._readMessageJSON(
@@ -6852,7 +6852,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Initializes a TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
+       * Initializes TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -6917,7 +6917,7 @@ export const TestIsInitialized = {
 
 export const TestDupFieldNumber = {
   /**
-   * Serializes a TestDupFieldNumber to protobuf.
+   * Serializes TestDupFieldNumber to protobuf.
    */
   encode: function (msg) {
     return TestDupFieldNumber._writeMessage(
@@ -6927,7 +6927,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from protobuf.
+   * Deserializes TestDupFieldNumber from protobuf.
    */
   decode: function (bytes) {
     return TestDupFieldNumber._readMessage(
@@ -6937,14 +6937,14 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Serializes a TestDupFieldNumber to JSON.
+   * Serializes TestDupFieldNumber to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDupFieldNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from JSON.
+   * Deserializes TestDupFieldNumber from JSON.
    */
   decodeJSON: function (json) {
     return TestDupFieldNumber._readMessageJSON(
@@ -6954,7 +6954,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Initializes a TestDupFieldNumber with all fields set to their default value.
+   * Initializes TestDupFieldNumber with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -7016,7 +7016,7 @@ export const TestDupFieldNumber = {
 
   Foo: {
     /**
-     * Serializes a TestDupFieldNumber.Foo to protobuf.
+     * Serializes TestDupFieldNumber.Foo to protobuf.
      */
     encode: function (msg) {
       return TestDupFieldNumber.Foo._writeMessage(
@@ -7026,7 +7026,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from protobuf.
+     * Deserializes TestDupFieldNumber.Foo from protobuf.
      */
     decode: function (bytes) {
       return TestDupFieldNumber.Foo._readMessage(
@@ -7036,14 +7036,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Foo to JSON.
+     * Serializes TestDupFieldNumber.Foo to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestDupFieldNumber.Foo._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from JSON.
+     * Deserializes TestDupFieldNumber.Foo from JSON.
      */
     decodeJSON: function (json) {
       return TestDupFieldNumber.Foo._readMessageJSON(
@@ -7053,7 +7053,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Foo with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Foo with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -7116,7 +7116,7 @@ export const TestDupFieldNumber = {
 
   Bar: {
     /**
-     * Serializes a TestDupFieldNumber.Bar to protobuf.
+     * Serializes TestDupFieldNumber.Bar to protobuf.
      */
     encode: function (msg) {
       return TestDupFieldNumber.Bar._writeMessage(
@@ -7126,7 +7126,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from protobuf.
+     * Deserializes TestDupFieldNumber.Bar from protobuf.
      */
     decode: function (bytes) {
       return TestDupFieldNumber.Bar._readMessage(
@@ -7136,14 +7136,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Bar to JSON.
+     * Serializes TestDupFieldNumber.Bar to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestDupFieldNumber.Bar._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from JSON.
+     * Deserializes TestDupFieldNumber.Bar from JSON.
      */
     decodeJSON: function (json) {
       return TestDupFieldNumber.Bar._readMessageJSON(
@@ -7153,7 +7153,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Bar with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Bar with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -7217,7 +7217,7 @@ export const TestDupFieldNumber = {
 
 export const TestEagerMessage = {
   /**
-   * Serializes a TestEagerMessage to protobuf.
+   * Serializes TestEagerMessage to protobuf.
    */
   encode: function (msg) {
     return TestEagerMessage._writeMessage(
@@ -7227,7 +7227,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Deserializes a TestEagerMessage from protobuf.
+   * Deserializes TestEagerMessage from protobuf.
    */
   decode: function (bytes) {
     return TestEagerMessage._readMessage(
@@ -7237,14 +7237,14 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Serializes a TestEagerMessage to JSON.
+   * Serializes TestEagerMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestEagerMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestEagerMessage from JSON.
+   * Deserializes TestEagerMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestEagerMessage._readMessageJSON(
@@ -7254,7 +7254,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Initializes a TestEagerMessage with all fields set to their default value.
+   * Initializes TestEagerMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -7322,7 +7322,7 @@ export const TestEagerMessage = {
 
 export const TestLazyMessage = {
   /**
-   * Serializes a TestLazyMessage to protobuf.
+   * Serializes TestLazyMessage to protobuf.
    */
   encode: function (msg) {
     return TestLazyMessage._writeMessage(
@@ -7332,7 +7332,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Deserializes a TestLazyMessage from protobuf.
+   * Deserializes TestLazyMessage from protobuf.
    */
   decode: function (bytes) {
     return TestLazyMessage._readMessage(
@@ -7342,14 +7342,14 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Serializes a TestLazyMessage to JSON.
+   * Serializes TestLazyMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestLazyMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestLazyMessage from JSON.
+   * Deserializes TestLazyMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestLazyMessage._readMessageJSON(
@@ -7359,7 +7359,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Initializes a TestLazyMessage with all fields set to their default value.
+   * Initializes TestLazyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -7427,7 +7427,7 @@ export const TestLazyMessage = {
 
 export const TestNestedMessageHasBits = {
   /**
-   * Serializes a TestNestedMessageHasBits to protobuf.
+   * Serializes TestNestedMessageHasBits to protobuf.
    */
   encode: function (msg) {
     return TestNestedMessageHasBits._writeMessage(
@@ -7437,7 +7437,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from protobuf.
+   * Deserializes TestNestedMessageHasBits from protobuf.
    */
   decode: function (bytes) {
     return TestNestedMessageHasBits._readMessage(
@@ -7447,14 +7447,14 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Serializes a TestNestedMessageHasBits to JSON.
+   * Serializes TestNestedMessageHasBits to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestNestedMessageHasBits._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from JSON.
+   * Deserializes TestNestedMessageHasBits from JSON.
    */
   decodeJSON: function (json) {
     return TestNestedMessageHasBits._readMessageJSON(
@@ -7464,7 +7464,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Initializes a TestNestedMessageHasBits with all fields set to their default value.
+   * Initializes TestNestedMessageHasBits with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -7546,7 +7546,7 @@ export const TestNestedMessageHasBits = {
 
   NestedMessage: {
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to protobuf.
+     * Serializes TestNestedMessageHasBits.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestNestedMessageHasBits.NestedMessage._writeMessage(
@@ -7556,7 +7556,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from protobuf.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestNestedMessageHasBits.NestedMessage._readMessage(
@@ -7566,7 +7566,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to JSON.
+     * Serializes TestNestedMessageHasBits.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -7575,7 +7575,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from JSON.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestNestedMessageHasBits.NestedMessage._readMessageJSON(
@@ -7585,7 +7585,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Initializes a TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
+     * Initializes TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -7680,7 +7680,7 @@ export const TestNestedMessageHasBits = {
 
 export const TestCamelCaseFieldNames = {
   /**
-   * Serializes a TestCamelCaseFieldNames to protobuf.
+   * Serializes TestCamelCaseFieldNames to protobuf.
    */
   encode: function (msg) {
     return TestCamelCaseFieldNames._writeMessage(
@@ -7690,7 +7690,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from protobuf.
+   * Deserializes TestCamelCaseFieldNames from protobuf.
    */
   decode: function (bytes) {
     return TestCamelCaseFieldNames._readMessage(
@@ -7700,14 +7700,14 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Serializes a TestCamelCaseFieldNames to JSON.
+   * Serializes TestCamelCaseFieldNames to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestCamelCaseFieldNames._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from JSON.
+   * Deserializes TestCamelCaseFieldNames from JSON.
    */
   decodeJSON: function (json) {
     return TestCamelCaseFieldNames._readMessageJSON(
@@ -7717,7 +7717,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Initializes a TestCamelCaseFieldNames with all fields set to their default value.
+   * Initializes TestCamelCaseFieldNames with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -7965,7 +7965,7 @@ export const TestCamelCaseFieldNames = {
 
 export const TestFieldOrderings = {
   /**
-   * Serializes a TestFieldOrderings to protobuf.
+   * Serializes TestFieldOrderings to protobuf.
    */
   encode: function (msg) {
     return TestFieldOrderings._writeMessage(
@@ -7975,7 +7975,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Deserializes a TestFieldOrderings from protobuf.
+   * Deserializes TestFieldOrderings from protobuf.
    */
   decode: function (bytes) {
     return TestFieldOrderings._readMessage(
@@ -7985,14 +7985,14 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Serializes a TestFieldOrderings to JSON.
+   * Serializes TestFieldOrderings to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestFieldOrderings._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestFieldOrderings from JSON.
+   * Deserializes TestFieldOrderings from JSON.
    */
   decodeJSON: function (json) {
     return TestFieldOrderings._readMessageJSON(
@@ -8002,7 +8002,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Initializes a TestFieldOrderings with all fields set to their default value.
+   * Initializes TestFieldOrderings with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -8128,7 +8128,7 @@ export const TestFieldOrderings = {
 
   NestedMessage: {
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to protobuf.
+     * Serializes TestFieldOrderings.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestFieldOrderings.NestedMessage._writeMessage(
@@ -8138,7 +8138,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from protobuf.
+     * Deserializes TestFieldOrderings.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestFieldOrderings.NestedMessage._readMessage(
@@ -8148,7 +8148,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to JSON.
+     * Serializes TestFieldOrderings.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -8157,7 +8157,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from JSON.
+     * Deserializes TestFieldOrderings.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestFieldOrderings.NestedMessage._readMessageJSON(
@@ -8167,7 +8167,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Initializes a TestFieldOrderings.NestedMessage with all fields set to their default value.
+     * Initializes TestFieldOrderings.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -8246,7 +8246,7 @@ export const TestFieldOrderings = {
 
 export const TestExtensionOrderings1 = {
   /**
-   * Serializes a TestExtensionOrderings1 to protobuf.
+   * Serializes TestExtensionOrderings1 to protobuf.
    */
   encode: function (msg) {
     return TestExtensionOrderings1._writeMessage(
@@ -8256,7 +8256,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from protobuf.
+   * Deserializes TestExtensionOrderings1 from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionOrderings1._readMessage(
@@ -8266,14 +8266,14 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings1 to JSON.
+   * Serializes TestExtensionOrderings1 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionOrderings1._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from JSON.
+   * Deserializes TestExtensionOrderings1 from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionOrderings1._readMessageJSON(
@@ -8283,7 +8283,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings1 with all fields set to their default value.
+   * Initializes TestExtensionOrderings1 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -8346,7 +8346,7 @@ export const TestExtensionOrderings1 = {
 
 export const TestExtensionOrderings2 = {
   /**
-   * Serializes a TestExtensionOrderings2 to protobuf.
+   * Serializes TestExtensionOrderings2 to protobuf.
    */
   encode: function (msg) {
     return TestExtensionOrderings2._writeMessage(
@@ -8356,7 +8356,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from protobuf.
+   * Deserializes TestExtensionOrderings2 from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionOrderings2._readMessage(
@@ -8366,14 +8366,14 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings2 to JSON.
+   * Serializes TestExtensionOrderings2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionOrderings2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from JSON.
+   * Deserializes TestExtensionOrderings2 from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionOrderings2._readMessageJSON(
@@ -8383,7 +8383,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings2 with all fields set to their default value.
+   * Initializes TestExtensionOrderings2 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -8445,7 +8445,7 @@ export const TestExtensionOrderings2 = {
 
   TestExtensionOrderings3: {
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
      */
     encode: function (msg) {
       return TestExtensionOrderings2.TestExtensionOrderings3._writeMessage(
@@ -8455,7 +8455,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
      */
     decode: function (bytes) {
       return TestExtensionOrderings2.TestExtensionOrderings3._readMessage(
@@ -8465,7 +8465,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -8474,7 +8474,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
      */
     decodeJSON: function (json) {
       return TestExtensionOrderings2.TestExtensionOrderings3._readMessageJSON(
@@ -8484,7 +8484,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Initializes a TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
+     * Initializes TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -8548,7 +8548,7 @@ export const TestExtensionOrderings2 = {
 
 export const TestExtremeDefaultValues = {
   /**
-   * Serializes a TestExtremeDefaultValues to protobuf.
+   * Serializes TestExtremeDefaultValues to protobuf.
    */
   encode: function (msg) {
     return TestExtremeDefaultValues._writeMessage(
@@ -8558,7 +8558,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from protobuf.
+   * Deserializes TestExtremeDefaultValues from protobuf.
    */
   decode: function (bytes) {
     return TestExtremeDefaultValues._readMessage(
@@ -8568,14 +8568,14 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Serializes a TestExtremeDefaultValues to JSON.
+   * Serializes TestExtremeDefaultValues to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtremeDefaultValues._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from JSON.
+   * Deserializes TestExtremeDefaultValues from JSON.
    */
   decodeJSON: function (json) {
     return TestExtremeDefaultValues._readMessageJSON(
@@ -8585,7 +8585,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Initializes a TestExtremeDefaultValues with all fields set to their default value.
+   * Initializes TestExtremeDefaultValues with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9041,7 +9041,7 @@ export const TestExtremeDefaultValues = {
 
 export const SparseEnumMessage = {
   /**
-   * Serializes a SparseEnumMessage to protobuf.
+   * Serializes SparseEnumMessage to protobuf.
    */
   encode: function (msg) {
     return SparseEnumMessage._writeMessage(
@@ -9051,7 +9051,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Deserializes a SparseEnumMessage from protobuf.
+   * Deserializes SparseEnumMessage from protobuf.
    */
   decode: function (bytes) {
     return SparseEnumMessage._readMessage(
@@ -9061,14 +9061,14 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Serializes a SparseEnumMessage to JSON.
+   * Serializes SparseEnumMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(SparseEnumMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SparseEnumMessage from JSON.
+   * Deserializes SparseEnumMessage from JSON.
    */
   decodeJSON: function (json) {
     return SparseEnumMessage._readMessageJSON(
@@ -9078,7 +9078,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Initializes a SparseEnumMessage with all fields set to their default value.
+   * Initializes SparseEnumMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9141,14 +9141,14 @@ export const SparseEnumMessage = {
 
 export const OneString = {
   /**
-   * Serializes a OneString to protobuf.
+   * Serializes OneString to protobuf.
    */
   encode: function (msg) {
     return OneString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneString from protobuf.
+   * Deserializes OneString from protobuf.
    */
   decode: function (bytes) {
     return OneString._readMessage(
@@ -9158,21 +9158,21 @@ export const OneString = {
   },
 
   /**
-   * Serializes a OneString to JSON.
+   * Serializes OneString to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneString from JSON.
+   * Deserializes OneString from JSON.
    */
   decodeJSON: function (json) {
     return OneString._readMessageJSON(OneString.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneString with all fields set to their default value.
+   * Initializes OneString with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9235,14 +9235,14 @@ export const OneString = {
 
 export const MoreString = {
   /**
-   * Serializes a MoreString to protobuf.
+   * Serializes MoreString to protobuf.
    */
   encode: function (msg) {
     return MoreString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreString from protobuf.
+   * Deserializes MoreString from protobuf.
    */
   decode: function (bytes) {
     return MoreString._readMessage(
@@ -9252,14 +9252,14 @@ export const MoreString = {
   },
 
   /**
-   * Serializes a MoreString to JSON.
+   * Serializes MoreString to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MoreString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreString from JSON.
+   * Deserializes MoreString from JSON.
    */
   decodeJSON: function (json) {
     return MoreString._readMessageJSON(
@@ -9269,7 +9269,7 @@ export const MoreString = {
   },
 
   /**
-   * Initializes a MoreString with all fields set to their default value.
+   * Initializes MoreString with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9332,14 +9332,14 @@ export const MoreString = {
 
 export const OneBytes = {
   /**
-   * Serializes a OneBytes to protobuf.
+   * Serializes OneBytes to protobuf.
    */
   encode: function (msg) {
     return OneBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneBytes from protobuf.
+   * Deserializes OneBytes from protobuf.
    */
   decode: function (bytes) {
     return OneBytes._readMessage(
@@ -9349,21 +9349,21 @@ export const OneBytes = {
   },
 
   /**
-   * Serializes a OneBytes to JSON.
+   * Serializes OneBytes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneBytes from JSON.
+   * Deserializes OneBytes from JSON.
    */
   decodeJSON: function (json) {
     return OneBytes._readMessageJSON(OneBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneBytes with all fields set to their default value.
+   * Initializes OneBytes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9426,14 +9426,14 @@ export const OneBytes = {
 
 export const MoreBytes = {
   /**
-   * Serializes a MoreBytes to protobuf.
+   * Serializes MoreBytes to protobuf.
    */
   encode: function (msg) {
     return MoreBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreBytes from protobuf.
+   * Deserializes MoreBytes from protobuf.
    */
   decode: function (bytes) {
     return MoreBytes._readMessage(
@@ -9443,21 +9443,21 @@ export const MoreBytes = {
   },
 
   /**
-   * Serializes a MoreBytes to JSON.
+   * Serializes MoreBytes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MoreBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreBytes from JSON.
+   * Deserializes MoreBytes from JSON.
    */
   decodeJSON: function (json) {
     return MoreBytes._readMessageJSON(MoreBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a MoreBytes with all fields set to their default value.
+   * Initializes MoreBytes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9520,7 +9520,7 @@ export const MoreBytes = {
 
 export const Int32Message = {
   /**
-   * Serializes a Int32Message to protobuf.
+   * Serializes Int32Message to protobuf.
    */
   encode: function (msg) {
     return Int32Message._writeMessage(
@@ -9530,7 +9530,7 @@ export const Int32Message = {
   },
 
   /**
-   * Deserializes a Int32Message from protobuf.
+   * Deserializes Int32Message from protobuf.
    */
   decode: function (bytes) {
     return Int32Message._readMessage(
@@ -9540,14 +9540,14 @@ export const Int32Message = {
   },
 
   /**
-   * Serializes a Int32Message to JSON.
+   * Serializes Int32Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Message from JSON.
+   * Deserializes Int32Message from JSON.
    */
   decodeJSON: function (json) {
     return Int32Message._readMessageJSON(
@@ -9557,7 +9557,7 @@ export const Int32Message = {
   },
 
   /**
-   * Initializes a Int32Message with all fields set to their default value.
+   * Initializes Int32Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9620,7 +9620,7 @@ export const Int32Message = {
 
 export const Uint32Message = {
   /**
-   * Serializes a Uint32Message to protobuf.
+   * Serializes Uint32Message to protobuf.
    */
   encode: function (msg) {
     return Uint32Message._writeMessage(
@@ -9630,7 +9630,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Deserializes a Uint32Message from protobuf.
+   * Deserializes Uint32Message from protobuf.
    */
   decode: function (bytes) {
     return Uint32Message._readMessage(
@@ -9640,14 +9640,14 @@ export const Uint32Message = {
   },
 
   /**
-   * Serializes a Uint32Message to JSON.
+   * Serializes Uint32Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Uint32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint32Message from JSON.
+   * Deserializes Uint32Message from JSON.
    */
   decodeJSON: function (json) {
     return Uint32Message._readMessageJSON(
@@ -9657,7 +9657,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Initializes a Uint32Message with all fields set to their default value.
+   * Initializes Uint32Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9720,7 +9720,7 @@ export const Uint32Message = {
 
 export const Int64Message = {
   /**
-   * Serializes a Int64Message to protobuf.
+   * Serializes Int64Message to protobuf.
    */
   encode: function (msg) {
     return Int64Message._writeMessage(
@@ -9730,7 +9730,7 @@ export const Int64Message = {
   },
 
   /**
-   * Deserializes a Int64Message from protobuf.
+   * Deserializes Int64Message from protobuf.
    */
   decode: function (bytes) {
     return Int64Message._readMessage(
@@ -9740,14 +9740,14 @@ export const Int64Message = {
   },
 
   /**
-   * Serializes a Int64Message to JSON.
+   * Serializes Int64Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Message from JSON.
+   * Deserializes Int64Message from JSON.
    */
   decodeJSON: function (json) {
     return Int64Message._readMessageJSON(
@@ -9757,7 +9757,7 @@ export const Int64Message = {
   },
 
   /**
-   * Initializes a Int64Message with all fields set to their default value.
+   * Initializes Int64Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9820,7 +9820,7 @@ export const Int64Message = {
 
 export const Uint64Message = {
   /**
-   * Serializes a Uint64Message to protobuf.
+   * Serializes Uint64Message to protobuf.
    */
   encode: function (msg) {
     return Uint64Message._writeMessage(
@@ -9830,7 +9830,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Deserializes a Uint64Message from protobuf.
+   * Deserializes Uint64Message from protobuf.
    */
   decode: function (bytes) {
     return Uint64Message._readMessage(
@@ -9840,14 +9840,14 @@ export const Uint64Message = {
   },
 
   /**
-   * Serializes a Uint64Message to JSON.
+   * Serializes Uint64Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Uint64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint64Message from JSON.
+   * Deserializes Uint64Message from JSON.
    */
   decodeJSON: function (json) {
     return Uint64Message._readMessageJSON(
@@ -9857,7 +9857,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Initializes a Uint64Message with all fields set to their default value.
+   * Initializes Uint64Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -9920,14 +9920,14 @@ export const Uint64Message = {
 
 export const BoolMessage = {
   /**
-   * Serializes a BoolMessage to protobuf.
+   * Serializes BoolMessage to protobuf.
    */
   encode: function (msg) {
     return BoolMessage._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolMessage from protobuf.
+   * Deserializes BoolMessage from protobuf.
    */
   decode: function (bytes) {
     return BoolMessage._readMessage(
@@ -9937,14 +9937,14 @@ export const BoolMessage = {
   },
 
   /**
-   * Serializes a BoolMessage to JSON.
+   * Serializes BoolMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BoolMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolMessage from JSON.
+   * Deserializes BoolMessage from JSON.
    */
   decodeJSON: function (json) {
     return BoolMessage._readMessageJSON(
@@ -9954,7 +9954,7 @@ export const BoolMessage = {
   },
 
   /**
-   * Initializes a BoolMessage with all fields set to their default value.
+   * Initializes BoolMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -10017,14 +10017,14 @@ export const BoolMessage = {
 
 export const TestOneof = {
   /**
-   * Serializes a TestOneof to protobuf.
+   * Serializes TestOneof to protobuf.
    */
   encode: function (msg) {
     return TestOneof._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof from protobuf.
+   * Deserializes TestOneof from protobuf.
    */
   decode: function (bytes) {
     return TestOneof._readMessage(
@@ -10034,21 +10034,21 @@ export const TestOneof = {
   },
 
   /**
-   * Serializes a TestOneof to JSON.
+   * Serializes TestOneof to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof from JSON.
+   * Deserializes TestOneof from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof._readMessageJSON(TestOneof.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestOneof with all fields set to their default value.
+   * Initializes TestOneof with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -10143,7 +10143,7 @@ export const TestOneof = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof.FooGroup to protobuf.
+     * Serializes TestOneof.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneof.FooGroup._writeMessage(
@@ -10153,7 +10153,7 @@ export const TestOneof = {
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from protobuf.
+     * Deserializes TestOneof.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneof.FooGroup._readMessage(
@@ -10163,14 +10163,14 @@ export const TestOneof = {
     },
 
     /**
-     * Serializes a TestOneof.FooGroup to JSON.
+     * Serializes TestOneof.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from JSON.
+     * Deserializes TestOneof.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof.FooGroup._readMessageJSON(
@@ -10180,7 +10180,7 @@ export const TestOneof = {
     },
 
     /**
-     * Initializes a TestOneof.FooGroup with all fields set to their default value.
+     * Initializes TestOneof.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -10259,7 +10259,7 @@ export const TestOneof = {
 
 export const TestOneofBackwardsCompatible = {
   /**
-   * Serializes a TestOneofBackwardsCompatible to protobuf.
+   * Serializes TestOneofBackwardsCompatible to protobuf.
    */
   encode: function (msg) {
     return TestOneofBackwardsCompatible._writeMessage(
@@ -10269,7 +10269,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from protobuf.
+   * Deserializes TestOneofBackwardsCompatible from protobuf.
    */
   decode: function (bytes) {
     return TestOneofBackwardsCompatible._readMessage(
@@ -10279,14 +10279,14 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Serializes a TestOneofBackwardsCompatible to JSON.
+   * Serializes TestOneofBackwardsCompatible to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneofBackwardsCompatible._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from JSON.
+   * Deserializes TestOneofBackwardsCompatible from JSON.
    */
   decodeJSON: function (json) {
     return TestOneofBackwardsCompatible._readMessageJSON(
@@ -10296,7 +10296,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Initializes a TestOneofBackwardsCompatible with all fields set to their default value.
+   * Initializes TestOneofBackwardsCompatible with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -10393,7 +10393,7 @@ export const TestOneofBackwardsCompatible = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to protobuf.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneofBackwardsCompatible.FooGroup._writeMessage(
@@ -10403,7 +10403,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from protobuf.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneofBackwardsCompatible.FooGroup._readMessage(
@@ -10413,7 +10413,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to JSON.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -10422,7 +10422,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from JSON.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneofBackwardsCompatible.FooGroup._readMessageJSON(
@@ -10432,7 +10432,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Initializes a TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
+     * Initializes TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -10511,14 +10511,14 @@ export const TestOneofBackwardsCompatible = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg) {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes) {
     return TestOneof2._readMessage(
@@ -10528,14 +10528,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof2._readMessageJSON(
@@ -10545,7 +10545,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -10959,7 +10959,7 @@ export const TestOneof2 = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof2.FooGroup to protobuf.
+     * Serializes TestOneof2.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneof2.FooGroup._writeMessage(
@@ -10969,7 +10969,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from protobuf.
+     * Deserializes TestOneof2.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneof2.FooGroup._readMessage(
@@ -10979,14 +10979,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.FooGroup to JSON.
+     * Serializes TestOneof2.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof2.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from JSON.
+     * Deserializes TestOneof2.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof2.FooGroup._readMessageJSON(
@@ -10996,7 +10996,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.FooGroup with all fields set to their default value.
+     * Initializes TestOneof2.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -11074,7 +11074,7 @@ export const TestOneof2 = {
 
   NestedMessage: {
     /**
-     * Serializes a TestOneof2.NestedMessage to protobuf.
+     * Serializes TestOneof2.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestOneof2.NestedMessage._writeMessage(
@@ -11084,7 +11084,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from protobuf.
+     * Deserializes TestOneof2.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestOneof2.NestedMessage._readMessage(
@@ -11094,14 +11094,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.NestedMessage to JSON.
+     * Serializes TestOneof2.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof2.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from JSON.
+     * Deserializes TestOneof2.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof2.NestedMessage._readMessageJSON(
@@ -11111,7 +11111,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.NestedMessage with all fields set to their default value.
+     * Initializes TestOneof2.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -11190,7 +11190,7 @@ export const TestOneof2 = {
 
 export const TestRequiredOneof = {
   /**
-   * Serializes a TestRequiredOneof to protobuf.
+   * Serializes TestRequiredOneof to protobuf.
    */
   encode: function (msg) {
     return TestRequiredOneof._writeMessage(
@@ -11200,7 +11200,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Deserializes a TestRequiredOneof from protobuf.
+   * Deserializes TestRequiredOneof from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredOneof._readMessage(
@@ -11210,14 +11210,14 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Serializes a TestRequiredOneof to JSON.
+   * Serializes TestRequiredOneof to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredOneof from JSON.
+   * Deserializes TestRequiredOneof from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredOneof._readMessageJSON(
@@ -11227,7 +11227,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Initializes a TestRequiredOneof with all fields set to their default value.
+   * Initializes TestRequiredOneof with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -11331,7 +11331,7 @@ export const TestRequiredOneof = {
 
   NestedMessage: {
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to protobuf.
+     * Serializes TestRequiredOneof.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestRequiredOneof.NestedMessage._writeMessage(
@@ -11341,7 +11341,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from protobuf.
+     * Deserializes TestRequiredOneof.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestRequiredOneof.NestedMessage._readMessage(
@@ -11351,7 +11351,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to JSON.
+     * Serializes TestRequiredOneof.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -11360,7 +11360,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from JSON.
+     * Deserializes TestRequiredOneof.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestRequiredOneof.NestedMessage._readMessageJSON(
@@ -11370,7 +11370,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Initializes a TestRequiredOneof.NestedMessage with all fields set to their default value.
+     * Initializes TestRequiredOneof.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -11434,7 +11434,7 @@ export const TestRequiredOneof = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestPackedTypes._writeMessage(
@@ -11444,7 +11444,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestPackedTypes._readMessage(
@@ -11454,14 +11454,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestPackedTypes._readMessageJSON(
@@ -11471,7 +11471,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -11744,7 +11744,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestUnpackedTypes._writeMessage(
@@ -11754,7 +11754,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestUnpackedTypes._readMessage(
@@ -11764,14 +11764,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestUnpackedTypes._readMessageJSON(
@@ -11781,7 +11781,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -12054,35 +12054,35 @@ export const TestUnpackedTypes = {
 
 export const TestPackedExtensions = {
   /**
-   * Serializes a TestPackedExtensions to protobuf.
+   * Serializes TestPackedExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPackedExtensions from protobuf.
+   * Deserializes TestPackedExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestPackedExtensions to JSON.
+   * Serializes TestPackedExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPackedExtensions from JSON.
+   * Deserializes TestPackedExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestPackedExtensions with all fields set to their default value.
+   * Initializes TestPackedExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -12119,35 +12119,35 @@ export const TestPackedExtensions = {
 
 export const TestUnpackedExtensions = {
   /**
-   * Serializes a TestUnpackedExtensions to protobuf.
+   * Serializes TestUnpackedExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from protobuf.
+   * Deserializes TestUnpackedExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestUnpackedExtensions to JSON.
+   * Serializes TestUnpackedExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from JSON.
+   * Deserializes TestUnpackedExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestUnpackedExtensions with all fields set to their default value.
+   * Initializes TestUnpackedExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -12184,7 +12184,7 @@ export const TestUnpackedExtensions = {
 
 export const TestDynamicExtensions = {
   /**
-   * Serializes a TestDynamicExtensions to protobuf.
+   * Serializes TestDynamicExtensions to protobuf.
    */
   encode: function (msg) {
     return TestDynamicExtensions._writeMessage(
@@ -12194,7 +12194,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from protobuf.
+   * Deserializes TestDynamicExtensions from protobuf.
    */
   decode: function (bytes) {
     return TestDynamicExtensions._readMessage(
@@ -12204,14 +12204,14 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Serializes a TestDynamicExtensions to JSON.
+   * Serializes TestDynamicExtensions to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDynamicExtensions._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from JSON.
+   * Deserializes TestDynamicExtensions from JSON.
    */
   decodeJSON: function (json) {
     return TestDynamicExtensions._readMessageJSON(
@@ -12221,7 +12221,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Initializes a TestDynamicExtensions with all fields set to their default value.
+   * Initializes TestDynamicExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -12462,7 +12462,7 @@ export const TestDynamicExtensions = {
 
   DynamicMessageType: {
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to protobuf.
+     * Serializes TestDynamicExtensions.DynamicMessageType to protobuf.
      */
     encode: function (msg) {
       return TestDynamicExtensions.DynamicMessageType._writeMessage(
@@ -12472,7 +12472,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from protobuf.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from protobuf.
      */
     decode: function (bytes) {
       return TestDynamicExtensions.DynamicMessageType._readMessage(
@@ -12482,7 +12482,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to JSON.
+     * Serializes TestDynamicExtensions.DynamicMessageType to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -12491,7 +12491,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from JSON.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from JSON.
      */
     decodeJSON: function (json) {
       return TestDynamicExtensions.DynamicMessageType._readMessageJSON(
@@ -12501,7 +12501,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Initializes a TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
+     * Initializes TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -12565,7 +12565,7 @@ export const TestDynamicExtensions = {
 
 export const TestRepeatedScalarDifferentTagSizes = {
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to protobuf.
+   * Serializes TestRepeatedScalarDifferentTagSizes to protobuf.
    */
   encode: function (msg) {
     return TestRepeatedScalarDifferentTagSizes._writeMessage(
@@ -12575,7 +12575,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from protobuf.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from protobuf.
    */
   decode: function (bytes) {
     return TestRepeatedScalarDifferentTagSizes._readMessage(
@@ -12585,7 +12585,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to JSON.
+   * Serializes TestRepeatedScalarDifferentTagSizes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(
@@ -12594,7 +12594,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from JSON.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from JSON.
    */
   decodeJSON: function (json) {
     return TestRepeatedScalarDifferentTagSizes._readMessageJSON(
@@ -12604,7 +12604,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Initializes a TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
+   * Initializes TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -12751,7 +12751,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
 
 export const TestParsingMerge = {
   /**
-   * Serializes a TestParsingMerge to protobuf.
+   * Serializes TestParsingMerge to protobuf.
    */
   encode: function (msg) {
     return TestParsingMerge._writeMessage(
@@ -12761,7 +12761,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Deserializes a TestParsingMerge from protobuf.
+   * Deserializes TestParsingMerge from protobuf.
    */
   decode: function (bytes) {
     return TestParsingMerge._readMessage(
@@ -12771,14 +12771,14 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Serializes a TestParsingMerge to JSON.
+   * Serializes TestParsingMerge to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestParsingMerge._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestParsingMerge from JSON.
+   * Deserializes TestParsingMerge from JSON.
    */
   decodeJSON: function (json) {
     return TestParsingMerge._readMessageJSON(
@@ -12788,7 +12788,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Initializes a TestParsingMerge with all fields set to their default value.
+   * Initializes TestParsingMerge with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -12906,7 +12906,7 @@ export const TestParsingMerge = {
 
   RepeatedFieldsGenerator: {
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to protobuf.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.RepeatedFieldsGenerator._writeMessage(
@@ -12916,7 +12916,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from protobuf.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.RepeatedFieldsGenerator._readMessage(
@@ -12926,7 +12926,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to JSON.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -12935,7 +12935,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from JSON.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.RepeatedFieldsGenerator._readMessageJSON(
@@ -12945,7 +12945,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -13097,7 +13097,7 @@ export const TestParsingMerge = {
 
     Group1: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
        */
       encode: function (msg) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._writeMessage(
@@ -13107,7 +13107,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
        */
       decode: function (bytes) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._readMessage(
@@ -13117,7 +13117,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -13126,7 +13126,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
        */
       decodeJSON: function (json) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._readMessageJSON(
@@ -13136,7 +13136,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -13204,7 +13204,7 @@ export const TestParsingMerge = {
 
     Group2: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
        */
       encode: function (msg) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._writeMessage(
@@ -13214,7 +13214,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
        */
       decode: function (bytes) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._readMessage(
@@ -13224,7 +13224,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -13233,7 +13233,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
        */
       decodeJSON: function (json) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._readMessageJSON(
@@ -13243,7 +13243,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -13312,7 +13312,7 @@ export const TestParsingMerge = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to protobuf.
+     * Serializes TestParsingMerge.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.OptionalGroup._writeMessage(
@@ -13322,7 +13322,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from protobuf.
+     * Deserializes TestParsingMerge.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.OptionalGroup._readMessage(
@@ -13332,7 +13332,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to JSON.
+     * Serializes TestParsingMerge.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -13341,7 +13341,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from JSON.
+     * Deserializes TestParsingMerge.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.OptionalGroup._readMessageJSON(
@@ -13351,7 +13351,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.OptionalGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -13429,7 +13429,7 @@ export const TestParsingMerge = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to protobuf.
+     * Serializes TestParsingMerge.RepeatedGroup to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.RepeatedGroup._writeMessage(
@@ -13439,7 +13439,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from protobuf.
+     * Deserializes TestParsingMerge.RepeatedGroup from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.RepeatedGroup._readMessage(
@@ -13449,7 +13449,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to JSON.
+     * Serializes TestParsingMerge.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -13458,7 +13458,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from JSON.
+     * Deserializes TestParsingMerge.RepeatedGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.RepeatedGroup._readMessageJSON(
@@ -13468,7 +13468,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -13547,7 +13547,7 @@ export const TestParsingMerge = {
 
 export const TestCommentInjectionMessage = {
   /**
-   * Serializes a TestCommentInjectionMessage to protobuf.
+   * Serializes TestCommentInjectionMessage to protobuf.
    */
   encode: function (msg) {
     return TestCommentInjectionMessage._writeMessage(
@@ -13557,7 +13557,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from protobuf.
+   * Deserializes TestCommentInjectionMessage from protobuf.
    */
   decode: function (bytes) {
     return TestCommentInjectionMessage._readMessage(
@@ -13567,14 +13567,14 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Serializes a TestCommentInjectionMessage to JSON.
+   * Serializes TestCommentInjectionMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestCommentInjectionMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from JSON.
+   * Deserializes TestCommentInjectionMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestCommentInjectionMessage._readMessageJSON(
@@ -13584,7 +13584,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Initializes a TestCommentInjectionMessage with all fields set to their default value.
+   * Initializes TestCommentInjectionMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -13647,35 +13647,35 @@ export const TestCommentInjectionMessage = {
 
 export const FooRequest = {
   /**
-   * Serializes a FooRequest to protobuf.
+   * Serializes FooRequest to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooRequest from protobuf.
+   * Deserializes FooRequest from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooRequest to JSON.
+   * Serializes FooRequest to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooRequest from JSON.
+   * Deserializes FooRequest from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooRequest with all fields set to their default value.
+   * Initializes FooRequest with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -13712,35 +13712,35 @@ export const FooRequest = {
 
 export const FooResponse = {
   /**
-   * Serializes a FooResponse to protobuf.
+   * Serializes FooResponse to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooResponse from protobuf.
+   * Deserializes FooResponse from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooResponse to JSON.
+   * Serializes FooResponse to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooResponse from JSON.
+   * Deserializes FooResponse from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooResponse with all fields set to their default value.
+   * Initializes FooResponse with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -13777,35 +13777,35 @@ export const FooResponse = {
 
 export const FooClientMessage = {
   /**
-   * Serializes a FooClientMessage to protobuf.
+   * Serializes FooClientMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooClientMessage from protobuf.
+   * Deserializes FooClientMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooClientMessage to JSON.
+   * Serializes FooClientMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooClientMessage from JSON.
+   * Deserializes FooClientMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooClientMessage with all fields set to their default value.
+   * Initializes FooClientMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -13842,35 +13842,35 @@ export const FooClientMessage = {
 
 export const FooServerMessage = {
   /**
-   * Serializes a FooServerMessage to protobuf.
+   * Serializes FooServerMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooServerMessage from protobuf.
+   * Deserializes FooServerMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooServerMessage to JSON.
+   * Serializes FooServerMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooServerMessage from JSON.
+   * Deserializes FooServerMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooServerMessage with all fields set to their default value.
+   * Initializes FooServerMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -13907,35 +13907,35 @@ export const FooServerMessage = {
 
 export const BarRequest = {
   /**
-   * Serializes a BarRequest to protobuf.
+   * Serializes BarRequest to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarRequest from protobuf.
+   * Deserializes BarRequest from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a BarRequest to JSON.
+   * Serializes BarRequest to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarRequest from JSON.
+   * Deserializes BarRequest from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a BarRequest with all fields set to their default value.
+   * Initializes BarRequest with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -13972,35 +13972,35 @@ export const BarRequest = {
 
 export const BarResponse = {
   /**
-   * Serializes a BarResponse to protobuf.
+   * Serializes BarResponse to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarResponse from protobuf.
+   * Deserializes BarResponse from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a BarResponse to JSON.
+   * Serializes BarResponse to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarResponse from JSON.
+   * Deserializes BarResponse from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a BarResponse with all fields set to their default value.
+   * Initializes BarResponse with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -14037,7 +14037,7 @@ export const BarResponse = {
 
 export const TestJsonName = {
   /**
-   * Serializes a TestJsonName to protobuf.
+   * Serializes TestJsonName to protobuf.
    */
   encode: function (msg) {
     return TestJsonName._writeMessage(
@@ -14047,7 +14047,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Deserializes a TestJsonName from protobuf.
+   * Deserializes TestJsonName from protobuf.
    */
   decode: function (bytes) {
     return TestJsonName._readMessage(
@@ -14057,14 +14057,14 @@ export const TestJsonName = {
   },
 
   /**
-   * Serializes a TestJsonName to JSON.
+   * Serializes TestJsonName to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestJsonName._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestJsonName from JSON.
+   * Deserializes TestJsonName from JSON.
    */
   decodeJSON: function (json) {
     return TestJsonName._readMessageJSON(
@@ -14074,7 +14074,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Initializes a TestJsonName with all fields set to their default value.
+   * Initializes TestJsonName with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -14227,7 +14227,7 @@ export const TestJsonName = {
 
 export const TestHugeFieldNumbers = {
   /**
-   * Serializes a TestHugeFieldNumbers to protobuf.
+   * Serializes TestHugeFieldNumbers to protobuf.
    */
   encode: function (msg) {
     return TestHugeFieldNumbers._writeMessage(
@@ -14237,7 +14237,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from protobuf.
+   * Deserializes TestHugeFieldNumbers from protobuf.
    */
   decode: function (bytes) {
     return TestHugeFieldNumbers._readMessage(
@@ -14247,14 +14247,14 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Serializes a TestHugeFieldNumbers to JSON.
+   * Serializes TestHugeFieldNumbers to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestHugeFieldNumbers._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from JSON.
+   * Deserializes TestHugeFieldNumbers from JSON.
    */
   decodeJSON: function (json) {
     return TestHugeFieldNumbers._readMessageJSON(
@@ -14264,7 +14264,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Initializes a TestHugeFieldNumbers with all fields set to their default value.
+   * Initializes TestHugeFieldNumbers with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -14551,7 +14551,7 @@ export const TestHugeFieldNumbers = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to protobuf.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestHugeFieldNumbers.OptionalGroup._writeMessage(
@@ -14561,7 +14561,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from protobuf.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestHugeFieldNumbers.OptionalGroup._readMessage(
@@ -14571,7 +14571,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to JSON.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -14580,7 +14580,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from JSON.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestHugeFieldNumbers.OptionalGroup._readMessageJSON(
@@ -14590,7 +14590,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Initializes a TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
+     * Initializes TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -14722,7 +14722,7 @@ export const TestHugeFieldNumbers = {
 
 export const TestExtensionInsideTable = {
   /**
-   * Serializes a TestExtensionInsideTable to protobuf.
+   * Serializes TestExtensionInsideTable to protobuf.
    */
   encode: function (msg) {
     return TestExtensionInsideTable._writeMessage(
@@ -14732,7 +14732,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from protobuf.
+   * Deserializes TestExtensionInsideTable from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionInsideTable._readMessage(
@@ -14742,14 +14742,14 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Serializes a TestExtensionInsideTable to JSON.
+   * Serializes TestExtensionInsideTable to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionInsideTable._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from JSON.
+   * Deserializes TestExtensionInsideTable from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionInsideTable._readMessageJSON(
@@ -14759,7 +14759,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Initializes a TestExtensionInsideTable with all fields set to their default value.
+   * Initializes TestExtensionInsideTable with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -14942,7 +14942,7 @@ export const TestExtensionInsideTable = {
 
 export const TestExtensionRangeSerialize = {
   /**
-   * Serializes a TestExtensionRangeSerialize to protobuf.
+   * Serializes TestExtensionRangeSerialize to protobuf.
    */
   encode: function (msg) {
     return TestExtensionRangeSerialize._writeMessage(
@@ -14952,7 +14952,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from protobuf.
+   * Deserializes TestExtensionRangeSerialize from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionRangeSerialize._readMessage(
@@ -14962,14 +14962,14 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Serializes a TestExtensionRangeSerialize to JSON.
+   * Serializes TestExtensionRangeSerialize to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionRangeSerialize._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from JSON.
+   * Deserializes TestExtensionRangeSerialize from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionRangeSerialize._readMessageJSON(
@@ -14979,7 +14979,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Initializes a TestExtensionRangeSerialize with all fields set to their default value.
+   * Initializes TestExtensionRangeSerialize with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -15165,35 +15165,35 @@ export const MapEnum = {
 
 export const TestMap = {
   /**
-   * Serializes a TestMap to protobuf.
+   * Serializes TestMap to protobuf.
    */
   encode: function (msg) {
     return TestMap._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestMap from protobuf.
+   * Deserializes TestMap from protobuf.
    */
   decode: function (bytes) {
     return TestMap._readMessage(TestMap.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a TestMap to JSON.
+   * Serializes TestMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMap from JSON.
+   * Deserializes TestMap from JSON.
    */
   decodeJSON: function (json) {
     return TestMap._readMessageJSON(TestMap.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestMap with all fields set to their default value.
+   * Initializes TestMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -17311,7 +17311,7 @@ export const TestMap = {
 
 export const TestMapSubmessage = {
   /**
-   * Serializes a TestMapSubmessage to protobuf.
+   * Serializes TestMapSubmessage to protobuf.
    */
   encode: function (msg) {
     return TestMapSubmessage._writeMessage(
@@ -17321,7 +17321,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Deserializes a TestMapSubmessage from protobuf.
+   * Deserializes TestMapSubmessage from protobuf.
    */
   decode: function (bytes) {
     return TestMapSubmessage._readMessage(
@@ -17331,14 +17331,14 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Serializes a TestMapSubmessage to JSON.
+   * Serializes TestMapSubmessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMapSubmessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMapSubmessage from JSON.
+   * Deserializes TestMapSubmessage from JSON.
    */
   decodeJSON: function (json) {
     return TestMapSubmessage._readMessageJSON(
@@ -17348,7 +17348,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Initializes a TestMapSubmessage with all fields set to their default value.
+   * Initializes TestMapSubmessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -17416,7 +17416,7 @@ export const TestMapSubmessage = {
 
 export const TestMessageMap = {
   /**
-   * Serializes a TestMessageMap to protobuf.
+   * Serializes TestMessageMap to protobuf.
    */
   encode: function (msg) {
     return TestMessageMap._writeMessage(
@@ -17426,7 +17426,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Deserializes a TestMessageMap from protobuf.
+   * Deserializes TestMessageMap from protobuf.
    */
   decode: function (bytes) {
     return TestMessageMap._readMessage(
@@ -17436,14 +17436,14 @@ export const TestMessageMap = {
   },
 
   /**
-   * Serializes a TestMessageMap to JSON.
+   * Serializes TestMessageMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageMap from JSON.
+   * Deserializes TestMessageMap from JSON.
    */
   decodeJSON: function (json) {
     return TestMessageMap._readMessageJSON(
@@ -17453,7 +17453,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Initializes a TestMessageMap with all fields set to their default value.
+   * Initializes TestMessageMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -17617,7 +17617,7 @@ export const TestMessageMap = {
 
 export const TestSameTypeMap = {
   /**
-   * Serializes a TestSameTypeMap to protobuf.
+   * Serializes TestSameTypeMap to protobuf.
    */
   encode: function (msg) {
     return TestSameTypeMap._writeMessage(
@@ -17627,7 +17627,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Deserializes a TestSameTypeMap from protobuf.
+   * Deserializes TestSameTypeMap from protobuf.
    */
   decode: function (bytes) {
     return TestSameTypeMap._readMessage(
@@ -17637,14 +17637,14 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Serializes a TestSameTypeMap to JSON.
+   * Serializes TestSameTypeMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestSameTypeMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestSameTypeMap from JSON.
+   * Deserializes TestSameTypeMap from JSON.
    */
   decodeJSON: function (json) {
     return TestSameTypeMap._readMessageJSON(
@@ -17654,7 +17654,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Initializes a TestSameTypeMap with all fields set to their default value.
+   * Initializes TestSameTypeMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -17912,7 +17912,7 @@ export const TestSameTypeMap = {
 
 export const TestRequiredMessageMap = {
   /**
-   * Serializes a TestRequiredMessageMap to protobuf.
+   * Serializes TestRequiredMessageMap to protobuf.
    */
   encode: function (msg) {
     return TestRequiredMessageMap._writeMessage(
@@ -17922,7 +17922,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from protobuf.
+   * Deserializes TestRequiredMessageMap from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredMessageMap._readMessage(
@@ -17932,14 +17932,14 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Serializes a TestRequiredMessageMap to JSON.
+   * Serializes TestRequiredMessageMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from JSON.
+   * Deserializes TestRequiredMessageMap from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredMessageMap._readMessageJSON(
@@ -17949,7 +17949,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Initializes a TestRequiredMessageMap with all fields set to their default value.
+   * Initializes TestRequiredMessageMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -18113,7 +18113,7 @@ export const TestRequiredMessageMap = {
 
 export const TestArenaMap = {
   /**
-   * Serializes a TestArenaMap to protobuf.
+   * Serializes TestArenaMap to protobuf.
    */
   encode: function (msg) {
     return TestArenaMap._writeMessage(
@@ -18123,7 +18123,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Deserializes a TestArenaMap from protobuf.
+   * Deserializes TestArenaMap from protobuf.
    */
   decode: function (bytes) {
     return TestArenaMap._readMessage(
@@ -18133,14 +18133,14 @@ export const TestArenaMap = {
   },
 
   /**
-   * Serializes a TestArenaMap to JSON.
+   * Serializes TestArenaMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestArenaMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestArenaMap from JSON.
+   * Deserializes TestArenaMap from JSON.
    */
   decodeJSON: function (json) {
     return TestArenaMap._readMessageJSON(
@@ -18150,7 +18150,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Initializes a TestArenaMap with all fields set to their default value.
+   * Initializes TestArenaMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20052,7 +20052,7 @@ export const TestArenaMap = {
 
 export const MessageContainingMapCalledEntry = {
   /**
-   * Serializes a MessageContainingMapCalledEntry to protobuf.
+   * Serializes MessageContainingMapCalledEntry to protobuf.
    */
   encode: function (msg) {
     return MessageContainingMapCalledEntry._writeMessage(
@@ -20062,7 +20062,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from protobuf.
+   * Deserializes MessageContainingMapCalledEntry from protobuf.
    */
   decode: function (bytes) {
     return MessageContainingMapCalledEntry._readMessage(
@@ -20072,7 +20072,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Serializes a MessageContainingMapCalledEntry to JSON.
+   * Serializes MessageContainingMapCalledEntry to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(
@@ -20081,7 +20081,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from JSON.
+   * Deserializes MessageContainingMapCalledEntry from JSON.
    */
   decodeJSON: function (json) {
     return MessageContainingMapCalledEntry._readMessageJSON(
@@ -20091,7 +20091,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Initializes a MessageContainingMapCalledEntry with all fields set to their default value.
+   * Initializes MessageContainingMapCalledEntry with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20247,7 +20247,7 @@ export const MessageContainingMapCalledEntry = {
 
 export const TestRecursiveMapMessage = {
   /**
-   * Serializes a TestRecursiveMapMessage to protobuf.
+   * Serializes TestRecursiveMapMessage to protobuf.
    */
   encode: function (msg) {
     return TestRecursiveMapMessage._writeMessage(
@@ -20257,7 +20257,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from protobuf.
+   * Deserializes TestRecursiveMapMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRecursiveMapMessage._readMessage(
@@ -20267,14 +20267,14 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMapMessage to JSON.
+   * Serializes TestRecursiveMapMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRecursiveMapMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from JSON.
+   * Deserializes TestRecursiveMapMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRecursiveMapMessage._readMessageJSON(
@@ -20284,7 +20284,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMapMessage with all fields set to their default value.
+   * Initializes TestRecursiveMapMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20479,35 +20479,35 @@ import {
 
 export const Any = {
   /**
-   * Serializes a Any to protobuf.
+   * Serializes Any to protobuf.
    */
   encode: function (msg) {
     return Any._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Any from protobuf.
+   * Deserializes Any from protobuf.
    */
   decode: function (bytes) {
     return Any._readMessage(Any.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Any to JSON.
+   * Serializes Any to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Any._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Any from JSON.
+   * Deserializes Any from JSON.
    */
   decodeJSON: function (json) {
     return Any._readMessageJSON(Any.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Any with all fields set to their default value.
+   * Initializes Any with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20610,7 +20610,7 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const SourceContext = {
   /**
-   * Serializes a SourceContext to protobuf.
+   * Serializes SourceContext to protobuf.
    */
   encode: function (msg) {
     return SourceContext._writeMessage(
@@ -20620,7 +20620,7 @@ export const SourceContext = {
   },
 
   /**
-   * Deserializes a SourceContext from protobuf.
+   * Deserializes SourceContext from protobuf.
    */
   decode: function (bytes) {
     return SourceContext._readMessage(
@@ -20630,14 +20630,14 @@ export const SourceContext = {
   },
 
   /**
-   * Serializes a SourceContext to JSON.
+   * Serializes SourceContext to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(SourceContext._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SourceContext from JSON.
+   * Deserializes SourceContext from JSON.
    */
   decodeJSON: function (json) {
     return SourceContext._readMessageJSON(
@@ -20647,7 +20647,7 @@ export const SourceContext = {
   },
 
   /**
-   * Initializes a SourceContext with all fields set to their default value.
+   * Initializes SourceContext with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20783,35 +20783,35 @@ export const Syntax = {
 
 export const Type = {
   /**
-   * Serializes a Type to protobuf.
+   * Serializes Type to protobuf.
    */
   encode: function (msg) {
     return Type._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Type from protobuf.
+   * Deserializes Type from protobuf.
    */
   decode: function (bytes) {
     return Type._readMessage(Type.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Type to JSON.
+   * Serializes Type to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Type._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Type from JSON.
+   * Deserializes Type from JSON.
    */
   decodeJSON: function (json) {
     return Type._readMessageJSON(Type.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Type with all fields set to their default value.
+   * Initializes Type with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -20966,35 +20966,35 @@ export const Type = {
 
 export const Field = {
   /**
-   * Serializes a Field to protobuf.
+   * Serializes Field to protobuf.
    */
   encode: function (msg) {
     return Field._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Field from protobuf.
+   * Deserializes Field from protobuf.
    */
   decode: function (bytes) {
     return Field._readMessage(Field.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Field to JSON.
+   * Serializes Field to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Field._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Field from JSON.
+   * Deserializes Field from JSON.
    */
   decodeJSON: function (json) {
     return Field._readMessageJSON(Field.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Field with all fields set to their default value.
+   * Initializes Field with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -21478,35 +21478,35 @@ export const Field = {
 
 export const Enum = {
   /**
-   * Serializes a Enum to protobuf.
+   * Serializes Enum to protobuf.
    */
   encode: function (msg) {
     return Enum._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Enum from protobuf.
+   * Deserializes Enum from protobuf.
    */
   decode: function (bytes) {
     return Enum._readMessage(Enum.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Enum to JSON.
+   * Serializes Enum to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Enum._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Enum from JSON.
+   * Deserializes Enum from JSON.
    */
   decodeJSON: function (json) {
     return Enum._readMessageJSON(Enum.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Enum with all fields set to their default value.
+   * Initializes Enum with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -21646,14 +21646,14 @@ export const Enum = {
 
 export const EnumValue = {
   /**
-   * Serializes a EnumValue to protobuf.
+   * Serializes EnumValue to protobuf.
    */
   encode: function (msg) {
     return EnumValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a EnumValue from protobuf.
+   * Deserializes EnumValue from protobuf.
    */
   decode: function (bytes) {
     return EnumValue._readMessage(
@@ -21663,21 +21663,21 @@ export const EnumValue = {
   },
 
   /**
-   * Serializes a EnumValue to JSON.
+   * Serializes EnumValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(EnumValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a EnumValue from JSON.
+   * Deserializes EnumValue from JSON.
    */
   decodeJSON: function (json) {
     return EnumValue._readMessageJSON(EnumValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a EnumValue with all fields set to their default value.
+   * Initializes EnumValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -21776,35 +21776,35 @@ export const EnumValue = {
 
 export const Option = {
   /**
-   * Serializes a Option to protobuf.
+   * Serializes Option to protobuf.
    */
   encode: function (msg) {
     return Option._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Option from protobuf.
+   * Deserializes Option from protobuf.
    */
   decode: function (bytes) {
     return Option._readMessage(Option.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Option to JSON.
+   * Serializes Option to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Option._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Option from JSON.
+   * Deserializes Option from JSON.
    */
   decodeJSON: function (json) {
     return Option._readMessageJSON(Option.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Option with all fields set to their default value.
+   * Initializes Option with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -21915,35 +21915,35 @@ import { SourceContext } from \\"./source_context.pb\\";
 
 export const Api = {
   /**
-   * Serializes a Api to protobuf.
+   * Serializes Api to protobuf.
    */
   encode: function (msg) {
     return Api._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Api from protobuf.
+   * Deserializes Api from protobuf.
    */
   decode: function (bytes) {
     return Api._readMessage(Api.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Api to JSON.
+   * Serializes Api to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Api._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Api from JSON.
+   * Deserializes Api from JSON.
    */
   decodeJSON: function (json) {
     return Api._readMessageJSON(Api.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Api with all fields set to their default value.
+   * Initializes Api with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -22119,35 +22119,35 @@ export const Api = {
 
 export const Method = {
   /**
-   * Serializes a Method to protobuf.
+   * Serializes Method to protobuf.
    */
   encode: function (msg) {
     return Method._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Method from protobuf.
+   * Deserializes Method from protobuf.
    */
   decode: function (bytes) {
     return Method._readMessage(Method.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Method to JSON.
+   * Serializes Method to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Method._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Method from JSON.
+   * Deserializes Method from JSON.
    */
   decodeJSON: function (json) {
     return Method._readMessageJSON(Method.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Method with all fields set to their default value.
+   * Initializes Method with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -22307,35 +22307,35 @@ export const Method = {
 
 export const Mixin = {
   /**
-   * Serializes a Mixin to protobuf.
+   * Serializes Mixin to protobuf.
    */
   encode: function (msg) {
     return Mixin._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Mixin from protobuf.
+   * Deserializes Mixin from protobuf.
    */
   decode: function (bytes) {
     return Mixin._readMessage(Mixin.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Mixin to JSON.
+   * Serializes Mixin to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Mixin._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Mixin from JSON.
+   * Deserializes Mixin from JSON.
    */
   decodeJSON: function (json) {
     return Mixin._readMessageJSON(Mixin.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Mixin with all fields set to their default value.
+   * Initializes Mixin with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -22438,14 +22438,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Duration = {
   /**
-   * Serializes a Duration to protobuf.
+   * Serializes Duration to protobuf.
    */
   encode: function (msg) {
     return Duration._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Duration from protobuf.
+   * Deserializes Duration from protobuf.
    */
   decode: function (bytes) {
     return Duration._readMessage(
@@ -22455,21 +22455,21 @@ export const Duration = {
   },
 
   /**
-   * Serializes a Duration to JSON.
+   * Serializes Duration to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Duration._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Duration from JSON.
+   * Deserializes Duration from JSON.
    */
   decodeJSON: function (json) {
     return Duration._readMessageJSON(Duration.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Duration with all fields set to their default value.
+   * Initializes Duration with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -22572,35 +22572,35 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Empty = {
   /**
-   * Serializes a Empty to protobuf.
+   * Serializes Empty to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a Empty from protobuf.
+   * Deserializes Empty from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a Empty to JSON.
+   * Serializes Empty to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a Empty from JSON.
+   * Deserializes Empty from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a Empty with all fields set to their default value.
+   * Initializes Empty with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -22662,14 +22662,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const FieldMask = {
   /**
-   * Serializes a FieldMask to protobuf.
+   * Serializes FieldMask to protobuf.
    */
   encode: function (msg) {
     return FieldMask._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FieldMask from protobuf.
+   * Deserializes FieldMask from protobuf.
    */
   decode: function (bytes) {
     return FieldMask._readMessage(
@@ -22679,21 +22679,21 @@ export const FieldMask = {
   },
 
   /**
-   * Serializes a FieldMask to JSON.
+   * Serializes FieldMask to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(FieldMask._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FieldMask from JSON.
+   * Deserializes FieldMask from JSON.
    */
   decodeJSON: function (json) {
     return FieldMask._readMessageJSON(FieldMask.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a FieldMask with all fields set to their default value.
+   * Initializes FieldMask with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -22816,35 +22816,35 @@ export const NullValue = {
 
 export const Struct = {
   /**
-   * Serializes a Struct to protobuf.
+   * Serializes Struct to protobuf.
    */
   encode: function (msg) {
     return Struct._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Struct from protobuf.
+   * Deserializes Struct from protobuf.
    */
   decode: function (bytes) {
     return Struct._readMessage(Struct.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Struct to JSON.
+   * Serializes Struct to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Struct._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Struct from JSON.
+   * Deserializes Struct from JSON.
    */
   decodeJSON: function (json) {
     return Struct._readMessageJSON(Struct.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Struct with all fields set to their default value.
+   * Initializes Struct with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23002,35 +23002,35 @@ export const Struct = {
 
 export const Value = {
   /**
-   * Serializes a Value to protobuf.
+   * Serializes Value to protobuf.
    */
   encode: function (msg) {
     return Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Value from protobuf.
+   * Deserializes Value from protobuf.
    */
   decode: function (bytes) {
     return Value._readMessage(Value.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Value to JSON.
+   * Serializes Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Value from JSON.
+   * Deserializes Value from JSON.
    */
   decodeJSON: function (json) {
     return Value._readMessageJSON(Value.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Value with all fields set to their default value.
+   * Initializes Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23174,14 +23174,14 @@ export const Value = {
 
 export const ListValue = {
   /**
-   * Serializes a ListValue to protobuf.
+   * Serializes ListValue to protobuf.
    */
   encode: function (msg) {
     return ListValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a ListValue from protobuf.
+   * Deserializes ListValue from protobuf.
    */
   decode: function (bytes) {
     return ListValue._readMessage(
@@ -23191,21 +23191,21 @@ export const ListValue = {
   },
 
   /**
-   * Serializes a ListValue to JSON.
+   * Serializes ListValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ListValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ListValue from JSON.
+   * Deserializes ListValue from JSON.
    */
   decodeJSON: function (json) {
     return ListValue._readMessageJSON(ListValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a ListValue with all fields set to their default value.
+   * Initializes ListValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23299,14 +23299,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Timestamp = {
   /**
-   * Serializes a Timestamp to protobuf.
+   * Serializes Timestamp to protobuf.
    */
   encode: function (msg) {
     return Timestamp._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Timestamp from protobuf.
+   * Deserializes Timestamp from protobuf.
    */
   decode: function (bytes) {
     return Timestamp._readMessage(
@@ -23316,21 +23316,21 @@ export const Timestamp = {
   },
 
   /**
-   * Serializes a Timestamp to JSON.
+   * Serializes Timestamp to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Timestamp._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Timestamp from JSON.
+   * Deserializes Timestamp from JSON.
    */
   decodeJSON: function (json) {
     return Timestamp._readMessageJSON(Timestamp.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Timestamp with all fields set to their default value.
+   * Initializes Timestamp with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23438,14 +23438,14 @@ import {
 
 export const DoubleValue = {
   /**
-   * Serializes a DoubleValue to protobuf.
+   * Serializes DoubleValue to protobuf.
    */
   encode: function (msg) {
     return DoubleValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a DoubleValue from protobuf.
+   * Deserializes DoubleValue from protobuf.
    */
   decode: function (bytes) {
     return DoubleValue._readMessage(
@@ -23455,14 +23455,14 @@ export const DoubleValue = {
   },
 
   /**
-   * Serializes a DoubleValue to JSON.
+   * Serializes DoubleValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(DoubleValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a DoubleValue from JSON.
+   * Deserializes DoubleValue from JSON.
    */
   decodeJSON: function (json) {
     return DoubleValue._readMessageJSON(
@@ -23472,7 +23472,7 @@ export const DoubleValue = {
   },
 
   /**
-   * Initializes a DoubleValue with all fields set to their default value.
+   * Initializes DoubleValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23535,14 +23535,14 @@ export const DoubleValue = {
 
 export const FloatValue = {
   /**
-   * Serializes a FloatValue to protobuf.
+   * Serializes FloatValue to protobuf.
    */
   encode: function (msg) {
     return FloatValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FloatValue from protobuf.
+   * Deserializes FloatValue from protobuf.
    */
   decode: function (bytes) {
     return FloatValue._readMessage(
@@ -23552,14 +23552,14 @@ export const FloatValue = {
   },
 
   /**
-   * Serializes a FloatValue to JSON.
+   * Serializes FloatValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(FloatValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FloatValue from JSON.
+   * Deserializes FloatValue from JSON.
    */
   decodeJSON: function (json) {
     return FloatValue._readMessageJSON(
@@ -23569,7 +23569,7 @@ export const FloatValue = {
   },
 
   /**
-   * Initializes a FloatValue with all fields set to their default value.
+   * Initializes FloatValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23632,14 +23632,14 @@ export const FloatValue = {
 
 export const Int64Value = {
   /**
-   * Serializes a Int64Value to protobuf.
+   * Serializes Int64Value to protobuf.
    */
   encode: function (msg) {
     return Int64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int64Value from protobuf.
+   * Deserializes Int64Value from protobuf.
    */
   decode: function (bytes) {
     return Int64Value._readMessage(
@@ -23649,14 +23649,14 @@ export const Int64Value = {
   },
 
   /**
-   * Serializes a Int64Value to JSON.
+   * Serializes Int64Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Value from JSON.
+   * Deserializes Int64Value from JSON.
    */
   decodeJSON: function (json) {
     return Int64Value._readMessageJSON(
@@ -23666,7 +23666,7 @@ export const Int64Value = {
   },
 
   /**
-   * Initializes a Int64Value with all fields set to their default value.
+   * Initializes Int64Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23729,14 +23729,14 @@ export const Int64Value = {
 
 export const UInt64Value = {
   /**
-   * Serializes a UInt64Value to protobuf.
+   * Serializes UInt64Value to protobuf.
    */
   encode: function (msg) {
     return UInt64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt64Value from protobuf.
+   * Deserializes UInt64Value from protobuf.
    */
   decode: function (bytes) {
     return UInt64Value._readMessage(
@@ -23746,14 +23746,14 @@ export const UInt64Value = {
   },
 
   /**
-   * Serializes a UInt64Value to JSON.
+   * Serializes UInt64Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(UInt64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt64Value from JSON.
+   * Deserializes UInt64Value from JSON.
    */
   decodeJSON: function (json) {
     return UInt64Value._readMessageJSON(
@@ -23763,7 +23763,7 @@ export const UInt64Value = {
   },
 
   /**
-   * Initializes a UInt64Value with all fields set to their default value.
+   * Initializes UInt64Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23826,14 +23826,14 @@ export const UInt64Value = {
 
 export const Int32Value = {
   /**
-   * Serializes a Int32Value to protobuf.
+   * Serializes Int32Value to protobuf.
    */
   encode: function (msg) {
     return Int32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int32Value from protobuf.
+   * Deserializes Int32Value from protobuf.
    */
   decode: function (bytes) {
     return Int32Value._readMessage(
@@ -23843,14 +23843,14 @@ export const Int32Value = {
   },
 
   /**
-   * Serializes a Int32Value to JSON.
+   * Serializes Int32Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Value from JSON.
+   * Deserializes Int32Value from JSON.
    */
   decodeJSON: function (json) {
     return Int32Value._readMessageJSON(
@@ -23860,7 +23860,7 @@ export const Int32Value = {
   },
 
   /**
-   * Initializes a Int32Value with all fields set to their default value.
+   * Initializes Int32Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -23923,14 +23923,14 @@ export const Int32Value = {
 
 export const UInt32Value = {
   /**
-   * Serializes a UInt32Value to protobuf.
+   * Serializes UInt32Value to protobuf.
    */
   encode: function (msg) {
     return UInt32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt32Value from protobuf.
+   * Deserializes UInt32Value from protobuf.
    */
   decode: function (bytes) {
     return UInt32Value._readMessage(
@@ -23940,14 +23940,14 @@ export const UInt32Value = {
   },
 
   /**
-   * Serializes a UInt32Value to JSON.
+   * Serializes UInt32Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(UInt32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt32Value from JSON.
+   * Deserializes UInt32Value from JSON.
    */
   decodeJSON: function (json) {
     return UInt32Value._readMessageJSON(
@@ -23957,7 +23957,7 @@ export const UInt32Value = {
   },
 
   /**
-   * Initializes a UInt32Value with all fields set to their default value.
+   * Initializes UInt32Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -24020,14 +24020,14 @@ export const UInt32Value = {
 
 export const BoolValue = {
   /**
-   * Serializes a BoolValue to protobuf.
+   * Serializes BoolValue to protobuf.
    */
   encode: function (msg) {
     return BoolValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolValue from protobuf.
+   * Deserializes BoolValue from protobuf.
    */
   decode: function (bytes) {
     return BoolValue._readMessage(
@@ -24037,21 +24037,21 @@ export const BoolValue = {
   },
 
   /**
-   * Serializes a BoolValue to JSON.
+   * Serializes BoolValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BoolValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolValue from JSON.
+   * Deserializes BoolValue from JSON.
    */
   decodeJSON: function (json) {
     return BoolValue._readMessageJSON(BoolValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a BoolValue with all fields set to their default value.
+   * Initializes BoolValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -24114,14 +24114,14 @@ export const BoolValue = {
 
 export const StringValue = {
   /**
-   * Serializes a StringValue to protobuf.
+   * Serializes StringValue to protobuf.
    */
   encode: function (msg) {
     return StringValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a StringValue from protobuf.
+   * Deserializes StringValue from protobuf.
    */
   decode: function (bytes) {
     return StringValue._readMessage(
@@ -24131,14 +24131,14 @@ export const StringValue = {
   },
 
   /**
-   * Serializes a StringValue to JSON.
+   * Serializes StringValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(StringValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a StringValue from JSON.
+   * Deserializes StringValue from JSON.
    */
   decodeJSON: function (json) {
     return StringValue._readMessageJSON(
@@ -24148,7 +24148,7 @@ export const StringValue = {
   },
 
   /**
-   * Initializes a StringValue with all fields set to their default value.
+   * Initializes StringValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -24211,14 +24211,14 @@ export const StringValue = {
 
 export const BytesValue = {
   /**
-   * Serializes a BytesValue to protobuf.
+   * Serializes BytesValue to protobuf.
    */
   encode: function (msg) {
     return BytesValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BytesValue from protobuf.
+   * Deserializes BytesValue from protobuf.
    */
   decode: function (bytes) {
     return BytesValue._readMessage(
@@ -24228,14 +24228,14 @@ export const BytesValue = {
   },
 
   /**
-   * Serializes a BytesValue to JSON.
+   * Serializes BytesValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BytesValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BytesValue from JSON.
+   * Deserializes BytesValue from JSON.
    */
   decodeJSON: function (json) {
     return BytesValue._readMessageJSON(
@@ -24245,7 +24245,7 @@ export const BytesValue = {
   },
 
   /**
-   * Initializes a BytesValue with all fields set to their default value.
+   * Initializes BytesValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -24354,7 +24354,7 @@ import {
 
 export const TestWellKnownTypes = {
   /**
-   * Serializes a TestWellKnownTypes to protobuf.
+   * Serializes TestWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return TestWellKnownTypes._writeMessage(
@@ -24364,7 +24364,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from protobuf.
+   * Deserializes TestWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return TestWellKnownTypes._readMessage(
@@ -24374,14 +24374,14 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Serializes a TestWellKnownTypes to JSON.
+   * Serializes TestWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from JSON.
+   * Deserializes TestWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestWellKnownTypes._readMessageJSON(
@@ -24391,7 +24391,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Initializes a TestWellKnownTypes with all fields set to their default value.
+   * Initializes TestWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -24829,7 +24829,7 @@ export const TestWellKnownTypes = {
 
 export const RepeatedWellKnownTypes = {
   /**
-   * Serializes a RepeatedWellKnownTypes to protobuf.
+   * Serializes RepeatedWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return RepeatedWellKnownTypes._writeMessage(
@@ -24839,7 +24839,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from protobuf.
+   * Deserializes RepeatedWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return RepeatedWellKnownTypes._readMessage(
@@ -24849,14 +24849,14 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Serializes a RepeatedWellKnownTypes to JSON.
+   * Serializes RepeatedWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(RepeatedWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from JSON.
+   * Deserializes RepeatedWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return RepeatedWellKnownTypes._readMessageJSON(
@@ -24866,7 +24866,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Initializes a RepeatedWellKnownTypes with all fields set to their default value.
+   * Initializes RepeatedWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -25323,7 +25323,7 @@ export const RepeatedWellKnownTypes = {
 
 export const OneofWellKnownTypes = {
   /**
-   * Serializes a OneofWellKnownTypes to protobuf.
+   * Serializes OneofWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return OneofWellKnownTypes._writeMessage(
@@ -25333,7 +25333,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from protobuf.
+   * Deserializes OneofWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return OneofWellKnownTypes._readMessage(
@@ -25343,14 +25343,14 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Serializes a OneofWellKnownTypes to JSON.
+   * Serializes OneofWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneofWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from JSON.
+   * Deserializes OneofWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return OneofWellKnownTypes._readMessageJSON(
@@ -25360,7 +25360,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Initializes a OneofWellKnownTypes with all fields set to their default value.
+   * Initializes OneofWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -25778,7 +25778,7 @@ export const OneofWellKnownTypes = {
 
 export const MapWellKnownTypes = {
   /**
-   * Serializes a MapWellKnownTypes to protobuf.
+   * Serializes MapWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return MapWellKnownTypes._writeMessage(
@@ -25788,7 +25788,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from protobuf.
+   * Deserializes MapWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return MapWellKnownTypes._readMessage(
@@ -25798,14 +25798,14 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Serializes a MapWellKnownTypes to JSON.
+   * Serializes MapWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MapWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from JSON.
+   * Deserializes MapWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return MapWellKnownTypes._readMessageJSON(
@@ -25815,7 +25815,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Initializes a MapWellKnownTypes with all fields set to their default value.
+   * Initializes MapWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -28006,7 +28006,7 @@ export const ForeignEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg) {
     return TestAllTypes._writeMessage(
@@ -28016,7 +28016,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return TestAllTypes._readMessage(
@@ -28026,14 +28026,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestAllTypes._readMessageJSON(
@@ -28043,7 +28043,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -29129,7 +29129,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -29139,7 +29139,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.NestedMessage._readMessage(
@@ -29149,14 +29149,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -29166,7 +29166,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -29230,7 +29230,7 @@ export const TestAllTypes = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestPackedTypes._writeMessage(
@@ -29240,7 +29240,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestPackedTypes._readMessage(
@@ -29250,14 +29250,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestPackedTypes._readMessageJSON(
@@ -29267,7 +29267,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -29540,7 +29540,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestUnpackedTypes._writeMessage(
@@ -29550,7 +29550,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestUnpackedTypes._readMessage(
@@ -29560,14 +29560,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestUnpackedTypes._readMessageJSON(
@@ -29577,7 +29577,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -29856,7 +29856,7 @@ export const TestUnpackedTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg) {
     return NestedTestAllTypes._writeMessage(
@@ -29866,7 +29866,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return NestedTestAllTypes._readMessage(
@@ -29876,14 +29876,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return NestedTestAllTypes._readMessageJSON(
@@ -29893,7 +29893,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -29981,7 +29981,7 @@ export const NestedTestAllTypes = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg) {
     return ForeignMessage._writeMessage(
@@ -29991,7 +29991,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes) {
     return ForeignMessage._readMessage(
@@ -30001,14 +30001,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json) {
     return ForeignMessage._readMessageJSON(
@@ -30018,7 +30018,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -30081,35 +30081,35 @@ export const ForeignMessage = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -30146,7 +30146,7 @@ export const TestEmptyMessage = {
 
 export const TestMessageWithDummy = {
   /**
-   * Serializes a TestMessageWithDummy to protobuf.
+   * Serializes TestMessageWithDummy to protobuf.
    */
   encode: function (msg) {
     return TestMessageWithDummy._writeMessage(
@@ -30156,7 +30156,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from protobuf.
+   * Deserializes TestMessageWithDummy from protobuf.
    */
   decode: function (bytes) {
     return TestMessageWithDummy._readMessage(
@@ -30166,14 +30166,14 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Serializes a TestMessageWithDummy to JSON.
+   * Serializes TestMessageWithDummy to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMessageWithDummy._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from JSON.
+   * Deserializes TestMessageWithDummy from JSON.
    */
   decodeJSON: function (json) {
     return TestMessageWithDummy._readMessageJSON(
@@ -30183,7 +30183,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Initializes a TestMessageWithDummy with all fields set to their default value.
+   * Initializes TestMessageWithDummy with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -30246,14 +30246,14 @@ export const TestMessageWithDummy = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg) {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes) {
     return TestOneof2._readMessage(
@@ -30263,14 +30263,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof2._readMessageJSON(
@@ -30280,7 +30280,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -30482,7 +30482,7 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const PublicImportMessage = {
   /**
-   * Serializes a PublicImportMessage to protobuf.
+   * Serializes PublicImportMessage to protobuf.
    */
   encode: function (msg) {
     return PublicImportMessage._writeMessage(
@@ -30492,7 +30492,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Deserializes a PublicImportMessage from protobuf.
+   * Deserializes PublicImportMessage from protobuf.
    */
   decode: function (bytes) {
     return PublicImportMessage._readMessage(
@@ -30502,14 +30502,14 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Serializes a PublicImportMessage to JSON.
+   * Serializes PublicImportMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(PublicImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a PublicImportMessage from JSON.
+   * Deserializes PublicImportMessage from JSON.
    */
   decodeJSON: function (json) {
     return PublicImportMessage._readMessageJSON(
@@ -30519,7 +30519,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Initializes a PublicImportMessage with all fields set to their default value.
+   * Initializes PublicImportMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -30706,7 +30706,7 @@ export const ImportEnumForMap = {
 
 export const ImportMessage = {
   /**
-   * Serializes a ImportMessage to protobuf.
+   * Serializes ImportMessage to protobuf.
    */
   encode: function (msg) {
     return ImportMessage._writeMessage(
@@ -30716,7 +30716,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Deserializes a ImportMessage from protobuf.
+   * Deserializes ImportMessage from protobuf.
    */
   decode: function (bytes) {
     return ImportMessage._readMessage(
@@ -30726,14 +30726,14 @@ export const ImportMessage = {
   },
 
   /**
-   * Serializes a ImportMessage to JSON.
+   * Serializes ImportMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ImportMessage from JSON.
+   * Deserializes ImportMessage from JSON.
    */
   decodeJSON: function (json) {
     return ImportMessage._readMessageJSON(
@@ -30743,7 +30743,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Initializes a ImportMessage with all fields set to their default value.
+   * Initializes ImportMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -31828,7 +31828,7 @@ export const VeryLargeEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg) {
     return TestAllTypes._writeMessage(
@@ -31838,7 +31838,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return TestAllTypes._readMessage(
@@ -31848,14 +31848,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestAllTypes._readMessageJSON(
@@ -31865,7 +31865,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -33264,7 +33264,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -33274,7 +33274,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.NestedMessage._readMessage(
@@ -33284,14 +33284,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -33301,7 +33301,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -33364,7 +33364,7 @@ export const TestAllTypes = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestAllTypes.OptionalGroup to protobuf.
+     * Serializes TestAllTypes.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.OptionalGroup._writeMessage(
@@ -33374,7 +33374,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from protobuf.
+     * Deserializes TestAllTypes.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.OptionalGroup._readMessage(
@@ -33384,14 +33384,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.OptionalGroup to JSON.
+     * Serializes TestAllTypes.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from JSON.
+     * Deserializes TestAllTypes.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.OptionalGroup._readMessageJSON(
@@ -33401,7 +33401,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.OptionalGroup with all fields set to their default value.
+     * Initializes TestAllTypes.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -33464,7 +33464,7 @@ export const TestAllTypes = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to protobuf.
+     * Serializes TestAllTypes.RepeatedGroup to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.RepeatedGroup._writeMessage(
@@ -33474,7 +33474,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from protobuf.
+     * Deserializes TestAllTypes.RepeatedGroup from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.RepeatedGroup._readMessage(
@@ -33484,14 +33484,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to JSON.
+     * Serializes TestAllTypes.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.RepeatedGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from JSON.
+     * Deserializes TestAllTypes.RepeatedGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.RepeatedGroup._readMessageJSON(
@@ -33501,7 +33501,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.RepeatedGroup with all fields set to their default value.
+     * Initializes TestAllTypes.RepeatedGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -33565,7 +33565,7 @@ export const TestAllTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg) {
     return NestedTestAllTypes._writeMessage(
@@ -33575,7 +33575,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return NestedTestAllTypes._readMessage(
@@ -33585,14 +33585,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return NestedTestAllTypes._readMessageJSON(
@@ -33602,7 +33602,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -33717,7 +33717,7 @@ export const NestedTestAllTypes = {
 
 export const TestDeprecatedFields = {
   /**
-   * Serializes a TestDeprecatedFields to protobuf.
+   * Serializes TestDeprecatedFields to protobuf.
    */
   encode: function (msg) {
     return TestDeprecatedFields._writeMessage(
@@ -33727,7 +33727,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from protobuf.
+   * Deserializes TestDeprecatedFields from protobuf.
    */
   decode: function (bytes) {
     return TestDeprecatedFields._readMessage(
@@ -33737,14 +33737,14 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Serializes a TestDeprecatedFields to JSON.
+   * Serializes TestDeprecatedFields to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDeprecatedFields._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from JSON.
+   * Deserializes TestDeprecatedFields from JSON.
    */
   decodeJSON: function (json) {
     return TestDeprecatedFields._readMessageJSON(
@@ -33754,7 +33754,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Initializes a TestDeprecatedFields with all fields set to their default value.
+   * Initializes TestDeprecatedFields with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -33832,35 +33832,35 @@ export const TestDeprecatedFields = {
 
 export const TestDeprecatedMessage = {
   /**
-   * Serializes a TestDeprecatedMessage to protobuf.
+   * Serializes TestDeprecatedMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from protobuf.
+   * Deserializes TestDeprecatedMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestDeprecatedMessage to JSON.
+   * Serializes TestDeprecatedMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from JSON.
+   * Deserializes TestDeprecatedMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestDeprecatedMessage with all fields set to their default value.
+   * Initializes TestDeprecatedMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -33897,7 +33897,7 @@ export const TestDeprecatedMessage = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg) {
     return ForeignMessage._writeMessage(
@@ -33907,7 +33907,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes) {
     return ForeignMessage._readMessage(
@@ -33917,14 +33917,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json) {
     return ForeignMessage._readMessageJSON(
@@ -33934,7 +33934,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -34012,35 +34012,35 @@ export const ForeignMessage = {
 
 export const TestReservedFields = {
   /**
-   * Serializes a TestReservedFields to protobuf.
+   * Serializes TestReservedFields to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestReservedFields from protobuf.
+   * Deserializes TestReservedFields from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestReservedFields to JSON.
+   * Serializes TestReservedFields to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestReservedFields from JSON.
+   * Deserializes TestReservedFields from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestReservedFields with all fields set to their default value.
+   * Initializes TestReservedFields with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -34077,35 +34077,35 @@ export const TestReservedFields = {
 
 export const TestAllExtensions = {
   /**
-   * Serializes a TestAllExtensions to protobuf.
+   * Serializes TestAllExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestAllExtensions from protobuf.
+   * Deserializes TestAllExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestAllExtensions to JSON.
+   * Serializes TestAllExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestAllExtensions from JSON.
+   * Deserializes TestAllExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestAllExtensions with all fields set to their default value.
+   * Initializes TestAllExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -34142,7 +34142,7 @@ export const TestAllExtensions = {
 
 export const OptionalGroup_extension = {
   /**
-   * Serializes a OptionalGroup_extension to protobuf.
+   * Serializes OptionalGroup_extension to protobuf.
    */
   encode: function (msg) {
     return OptionalGroup_extension._writeMessage(
@@ -34152,7 +34152,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from protobuf.
+   * Deserializes OptionalGroup_extension from protobuf.
    */
   decode: function (bytes) {
     return OptionalGroup_extension._readMessage(
@@ -34162,14 +34162,14 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Serializes a OptionalGroup_extension to JSON.
+   * Serializes OptionalGroup_extension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OptionalGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from JSON.
+   * Deserializes OptionalGroup_extension from JSON.
    */
   decodeJSON: function (json) {
     return OptionalGroup_extension._readMessageJSON(
@@ -34179,7 +34179,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Initializes a OptionalGroup_extension with all fields set to their default value.
+   * Initializes OptionalGroup_extension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -34242,7 +34242,7 @@ export const OptionalGroup_extension = {
 
 export const RepeatedGroup_extension = {
   /**
-   * Serializes a RepeatedGroup_extension to protobuf.
+   * Serializes RepeatedGroup_extension to protobuf.
    */
   encode: function (msg) {
     return RepeatedGroup_extension._writeMessage(
@@ -34252,7 +34252,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from protobuf.
+   * Deserializes RepeatedGroup_extension from protobuf.
    */
   decode: function (bytes) {
     return RepeatedGroup_extension._readMessage(
@@ -34262,14 +34262,14 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Serializes a RepeatedGroup_extension to JSON.
+   * Serializes RepeatedGroup_extension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(RepeatedGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from JSON.
+   * Deserializes RepeatedGroup_extension from JSON.
    */
   decodeJSON: function (json) {
     return RepeatedGroup_extension._readMessageJSON(
@@ -34279,7 +34279,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Initializes a RepeatedGroup_extension with all fields set to their default value.
+   * Initializes RepeatedGroup_extension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -34342,14 +34342,14 @@ export const RepeatedGroup_extension = {
 
 export const TestGroup = {
   /**
-   * Serializes a TestGroup to protobuf.
+   * Serializes TestGroup to protobuf.
    */
   encode: function (msg) {
     return TestGroup._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestGroup from protobuf.
+   * Deserializes TestGroup from protobuf.
    */
   decode: function (bytes) {
     return TestGroup._readMessage(
@@ -34359,21 +34359,21 @@ export const TestGroup = {
   },
 
   /**
-   * Serializes a TestGroup to JSON.
+   * Serializes TestGroup to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestGroup._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestGroup from JSON.
+   * Deserializes TestGroup from JSON.
    */
   decodeJSON: function (json) {
     return TestGroup._readMessageJSON(TestGroup.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestGroup with all fields set to their default value.
+   * Initializes TestGroup with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -34442,7 +34442,7 @@ export const TestGroup = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestGroup.OptionalGroup to protobuf.
+     * Serializes TestGroup.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestGroup.OptionalGroup._writeMessage(
@@ -34452,7 +34452,7 @@ export const TestGroup = {
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from protobuf.
+     * Deserializes TestGroup.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestGroup.OptionalGroup._readMessage(
@@ -34462,14 +34462,14 @@ export const TestGroup = {
     },
 
     /**
-     * Serializes a TestGroup.OptionalGroup to JSON.
+     * Serializes TestGroup.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestGroup.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from JSON.
+     * Deserializes TestGroup.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestGroup.OptionalGroup._readMessageJSON(
@@ -34479,7 +34479,7 @@ export const TestGroup = {
     },
 
     /**
-     * Initializes a TestGroup.OptionalGroup with all fields set to their default value.
+     * Initializes TestGroup.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -34543,35 +34543,35 @@ export const TestGroup = {
 
 export const TestGroupExtension = {
   /**
-   * Serializes a TestGroupExtension to protobuf.
+   * Serializes TestGroupExtension to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestGroupExtension from protobuf.
+   * Deserializes TestGroupExtension from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestGroupExtension to JSON.
+   * Serializes TestGroupExtension to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestGroupExtension from JSON.
+   * Deserializes TestGroupExtension from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestGroupExtension with all fields set to their default value.
+   * Initializes TestGroupExtension with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -34608,35 +34608,35 @@ export const TestGroupExtension = {
 
 export const TestNestedExtension = {
   /**
-   * Serializes a TestNestedExtension to protobuf.
+   * Serializes TestNestedExtension to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestNestedExtension from protobuf.
+   * Deserializes TestNestedExtension from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestNestedExtension to JSON.
+   * Serializes TestNestedExtension to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestNestedExtension from JSON.
+   * Deserializes TestNestedExtension from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestNestedExtension with all fields set to their default value.
+   * Initializes TestNestedExtension with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -34672,7 +34672,7 @@ export const TestNestedExtension = {
 
   OptionalGroup_extension: {
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to protobuf.
+     * Serializes TestNestedExtension.OptionalGroup_extension to protobuf.
      */
     encode: function (msg) {
       return TestNestedExtension.OptionalGroup_extension._writeMessage(
@@ -34682,7 +34682,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from protobuf.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from protobuf.
      */
     decode: function (bytes) {
       return TestNestedExtension.OptionalGroup_extension._readMessage(
@@ -34692,7 +34692,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to JSON.
+     * Serializes TestNestedExtension.OptionalGroup_extension to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -34701,7 +34701,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from JSON.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from JSON.
      */
     decodeJSON: function (json) {
       return TestNestedExtension.OptionalGroup_extension._readMessageJSON(
@@ -34711,7 +34711,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Initializes a TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
+     * Initializes TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -34775,7 +34775,7 @@ export const TestNestedExtension = {
 
 export const TestChildExtension = {
   /**
-   * Serializes a TestChildExtension to protobuf.
+   * Serializes TestChildExtension to protobuf.
    */
   encode: function (msg) {
     return TestChildExtension._writeMessage(
@@ -34785,7 +34785,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Deserializes a TestChildExtension from protobuf.
+   * Deserializes TestChildExtension from protobuf.
    */
   decode: function (bytes) {
     return TestChildExtension._readMessage(
@@ -34795,14 +34795,14 @@ export const TestChildExtension = {
   },
 
   /**
-   * Serializes a TestChildExtension to JSON.
+   * Serializes TestChildExtension to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestChildExtension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestChildExtension from JSON.
+   * Deserializes TestChildExtension from JSON.
    */
   decodeJSON: function (json) {
     return TestChildExtension._readMessageJSON(
@@ -34812,7 +34812,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Initializes a TestChildExtension with all fields set to their default value.
+   * Initializes TestChildExtension with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -34920,7 +34920,7 @@ export const TestChildExtension = {
 
 export const TestRequired = {
   /**
-   * Serializes a TestRequired to protobuf.
+   * Serializes TestRequired to protobuf.
    */
   encode: function (msg) {
     return TestRequired._writeMessage(
@@ -34930,7 +34930,7 @@ export const TestRequired = {
   },
 
   /**
-   * Deserializes a TestRequired from protobuf.
+   * Deserializes TestRequired from protobuf.
    */
   decode: function (bytes) {
     return TestRequired._readMessage(
@@ -34940,14 +34940,14 @@ export const TestRequired = {
   },
 
   /**
-   * Serializes a TestRequired to JSON.
+   * Serializes TestRequired to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequired._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequired from JSON.
+   * Deserializes TestRequired from JSON.
    */
   decodeJSON: function (json) {
     return TestRequired._readMessageJSON(
@@ -34957,7 +34957,7 @@ export const TestRequired = {
   },
 
   /**
-   * Initializes a TestRequired with all fields set to their default value.
+   * Initializes TestRequired with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -35500,7 +35500,7 @@ export const TestRequired = {
 
 export const TestRequiredForeign = {
   /**
-   * Serializes a TestRequiredForeign to protobuf.
+   * Serializes TestRequiredForeign to protobuf.
    */
   encode: function (msg) {
     return TestRequiredForeign._writeMessage(
@@ -35510,7 +35510,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Deserializes a TestRequiredForeign from protobuf.
+   * Deserializes TestRequiredForeign from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredForeign._readMessage(
@@ -35520,14 +35520,14 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Serializes a TestRequiredForeign to JSON.
+   * Serializes TestRequiredForeign to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredForeign._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredForeign from JSON.
+   * Deserializes TestRequiredForeign from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredForeign._readMessageJSON(
@@ -35537,7 +35537,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Initializes a TestRequiredForeign with all fields set to their default value.
+   * Initializes TestRequiredForeign with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -35649,7 +35649,7 @@ export const TestRequiredForeign = {
 
 export const TestRequiredMessage = {
   /**
-   * Serializes a TestRequiredMessage to protobuf.
+   * Serializes TestRequiredMessage to protobuf.
    */
   encode: function (msg) {
     return TestRequiredMessage._writeMessage(
@@ -35659,7 +35659,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Deserializes a TestRequiredMessage from protobuf.
+   * Deserializes TestRequiredMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredMessage._readMessage(
@@ -35669,14 +35669,14 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Serializes a TestRequiredMessage to JSON.
+   * Serializes TestRequiredMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessage from JSON.
+   * Deserializes TestRequiredMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredMessage._readMessageJSON(
@@ -35686,7 +35686,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Initializes a TestRequiredMessage with all fields set to their default value.
+   * Initializes TestRequiredMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -35805,7 +35805,7 @@ export const TestRequiredMessage = {
 
 export const TestForeignNested = {
   /**
-   * Serializes a TestForeignNested to protobuf.
+   * Serializes TestForeignNested to protobuf.
    */
   encode: function (msg) {
     return TestForeignNested._writeMessage(
@@ -35815,7 +35815,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Deserializes a TestForeignNested from protobuf.
+   * Deserializes TestForeignNested from protobuf.
    */
   decode: function (bytes) {
     return TestForeignNested._readMessage(
@@ -35825,14 +35825,14 @@ export const TestForeignNested = {
   },
 
   /**
-   * Serializes a TestForeignNested to JSON.
+   * Serializes TestForeignNested to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestForeignNested._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestForeignNested from JSON.
+   * Deserializes TestForeignNested from JSON.
    */
   decodeJSON: function (json) {
     return TestForeignNested._readMessageJSON(
@@ -35842,7 +35842,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Initializes a TestForeignNested with all fields set to their default value.
+   * Initializes TestForeignNested with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -35919,35 +35919,35 @@ export const TestForeignNested = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -35984,35 +35984,35 @@ export const TestEmptyMessage = {
 
 export const TestEmptyMessageWithExtensions = {
   /**
-   * Serializes a TestEmptyMessageWithExtensions to protobuf.
+   * Serializes TestEmptyMessageWithExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from protobuf.
+   * Deserializes TestEmptyMessageWithExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessageWithExtensions to JSON.
+   * Serializes TestEmptyMessageWithExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from JSON.
+   * Deserializes TestEmptyMessageWithExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessageWithExtensions with all fields set to their default value.
+   * Initializes TestEmptyMessageWithExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -36049,35 +36049,35 @@ export const TestEmptyMessageWithExtensions = {
 
 export const TestPickleNestedMessage = {
   /**
-   * Serializes a TestPickleNestedMessage to protobuf.
+   * Serializes TestPickleNestedMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from protobuf.
+   * Deserializes TestPickleNestedMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestPickleNestedMessage to JSON.
+   * Serializes TestPickleNestedMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from JSON.
+   * Deserializes TestPickleNestedMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestPickleNestedMessage with all fields set to their default value.
+   * Initializes TestPickleNestedMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -36113,7 +36113,7 @@ export const TestPickleNestedMessage = {
 
   NestedMessage: {
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to protobuf.
+     * Serializes TestPickleNestedMessage.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestPickleNestedMessage.NestedMessage._writeMessage(
@@ -36123,7 +36123,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from protobuf.
+     * Deserializes TestPickleNestedMessage.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestPickleNestedMessage.NestedMessage._readMessage(
@@ -36133,7 +36133,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to JSON.
+     * Serializes TestPickleNestedMessage.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -36142,7 +36142,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from JSON.
+     * Deserializes TestPickleNestedMessage.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestPickleNestedMessage.NestedMessage._readMessageJSON(
@@ -36152,7 +36152,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Initializes a TestPickleNestedMessage.NestedMessage with all fields set to their default value.
+     * Initializes TestPickleNestedMessage.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -36214,7 +36214,7 @@ export const TestPickleNestedMessage = {
 
     NestedNestedMessage: {
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
        */
       encode: function (msg) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._writeMessage(
@@ -36224,7 +36224,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
        */
       decode: function (bytes) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._readMessage(
@@ -36234,7 +36234,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -36245,7 +36245,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
        */
       decodeJSON: function (json) {
         return TestPickleNestedMessage.NestedMessage.NestedNestedMessage._readMessageJSON(
@@ -36255,7 +36255,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Initializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
+       * Initializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -36320,35 +36320,35 @@ export const TestPickleNestedMessage = {
 
 export const TestMultipleExtensionRanges = {
   /**
-   * Serializes a TestMultipleExtensionRanges to protobuf.
+   * Serializes TestMultipleExtensionRanges to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from protobuf.
+   * Deserializes TestMultipleExtensionRanges from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestMultipleExtensionRanges to JSON.
+   * Serializes TestMultipleExtensionRanges to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from JSON.
+   * Deserializes TestMultipleExtensionRanges from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestMultipleExtensionRanges with all fields set to their default value.
+   * Initializes TestMultipleExtensionRanges with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -36385,7 +36385,7 @@ export const TestMultipleExtensionRanges = {
 
 export const TestReallyLargeTagNumber = {
   /**
-   * Serializes a TestReallyLargeTagNumber to protobuf.
+   * Serializes TestReallyLargeTagNumber to protobuf.
    */
   encode: function (msg) {
     return TestReallyLargeTagNumber._writeMessage(
@@ -36395,7 +36395,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from protobuf.
+   * Deserializes TestReallyLargeTagNumber from protobuf.
    */
   decode: function (bytes) {
     return TestReallyLargeTagNumber._readMessage(
@@ -36405,14 +36405,14 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Serializes a TestReallyLargeTagNumber to JSON.
+   * Serializes TestReallyLargeTagNumber to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestReallyLargeTagNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from JSON.
+   * Deserializes TestReallyLargeTagNumber from JSON.
    */
   decodeJSON: function (json) {
     return TestReallyLargeTagNumber._readMessageJSON(
@@ -36422,7 +36422,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Initializes a TestReallyLargeTagNumber with all fields set to their default value.
+   * Initializes TestReallyLargeTagNumber with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -36500,7 +36500,7 @@ export const TestReallyLargeTagNumber = {
 
 export const TestRecursiveMessage = {
   /**
-   * Serializes a TestRecursiveMessage to protobuf.
+   * Serializes TestRecursiveMessage to protobuf.
    */
   encode: function (msg) {
     return TestRecursiveMessage._writeMessage(
@@ -36510,7 +36510,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from protobuf.
+   * Deserializes TestRecursiveMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRecursiveMessage._readMessage(
@@ -36520,14 +36520,14 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMessage to JSON.
+   * Serializes TestRecursiveMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRecursiveMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from JSON.
+   * Deserializes TestRecursiveMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRecursiveMessage._readMessageJSON(
@@ -36537,7 +36537,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMessage with all fields set to their default value.
+   * Initializes TestRecursiveMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -36620,7 +36620,7 @@ export const TestRecursiveMessage = {
 
 export const TestMutualRecursionA = {
   /**
-   * Serializes a TestMutualRecursionA to protobuf.
+   * Serializes TestMutualRecursionA to protobuf.
    */
   encode: function (msg) {
     return TestMutualRecursionA._writeMessage(
@@ -36630,7 +36630,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from protobuf.
+   * Deserializes TestMutualRecursionA from protobuf.
    */
   decode: function (bytes) {
     return TestMutualRecursionA._readMessage(
@@ -36640,14 +36640,14 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Serializes a TestMutualRecursionA to JSON.
+   * Serializes TestMutualRecursionA to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMutualRecursionA._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from JSON.
+   * Deserializes TestMutualRecursionA from JSON.
    */
   decodeJSON: function (json) {
     return TestMutualRecursionA._readMessageJSON(
@@ -36657,7 +36657,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Initializes a TestMutualRecursionA with all fields set to their default value.
+   * Initializes TestMutualRecursionA with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -36724,7 +36724,7 @@ export const TestMutualRecursionA = {
 
   SubMessage: {
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to protobuf.
+     * Serializes TestMutualRecursionA.SubMessage to protobuf.
      */
     encode: function (msg) {
       return TestMutualRecursionA.SubMessage._writeMessage(
@@ -36734,7 +36734,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from protobuf.
+     * Deserializes TestMutualRecursionA.SubMessage from protobuf.
      */
     decode: function (bytes) {
       return TestMutualRecursionA.SubMessage._readMessage(
@@ -36744,7 +36744,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to JSON.
+     * Serializes TestMutualRecursionA.SubMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -36753,7 +36753,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from JSON.
+     * Deserializes TestMutualRecursionA.SubMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestMutualRecursionA.SubMessage._readMessageJSON(
@@ -36763,7 +36763,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubMessage with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -36831,7 +36831,7 @@ export const TestMutualRecursionA = {
 
   SubGroup: {
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to protobuf.
+     * Serializes TestMutualRecursionA.SubGroup to protobuf.
      */
     encode: function (msg) {
       return TestMutualRecursionA.SubGroup._writeMessage(
@@ -36841,7 +36841,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from protobuf.
+     * Deserializes TestMutualRecursionA.SubGroup from protobuf.
      */
     decode: function (bytes) {
       return TestMutualRecursionA.SubGroup._readMessage(
@@ -36851,7 +36851,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to JSON.
+     * Serializes TestMutualRecursionA.SubGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -36860,7 +36860,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from JSON.
+     * Deserializes TestMutualRecursionA.SubGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestMutualRecursionA.SubGroup._readMessageJSON(
@@ -36870,7 +36870,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubGroup with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -36968,7 +36968,7 @@ export const TestMutualRecursionA = {
 
 export const TestMutualRecursionB = {
   /**
-   * Serializes a TestMutualRecursionB to protobuf.
+   * Serializes TestMutualRecursionB to protobuf.
    */
   encode: function (msg) {
     return TestMutualRecursionB._writeMessage(
@@ -36978,7 +36978,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from protobuf.
+   * Deserializes TestMutualRecursionB from protobuf.
    */
   decode: function (bytes) {
     return TestMutualRecursionB._readMessage(
@@ -36988,14 +36988,14 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Serializes a TestMutualRecursionB to JSON.
+   * Serializes TestMutualRecursionB to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMutualRecursionB._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from JSON.
+   * Deserializes TestMutualRecursionB from JSON.
    */
   decodeJSON: function (json) {
     return TestMutualRecursionB._readMessageJSON(
@@ -37005,7 +37005,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Initializes a TestMutualRecursionB with all fields set to their default value.
+   * Initializes TestMutualRecursionB with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37088,7 +37088,7 @@ export const TestMutualRecursionB = {
 
 export const TestIsInitialized = {
   /**
-   * Serializes a TestIsInitialized to protobuf.
+   * Serializes TestIsInitialized to protobuf.
    */
   encode: function (msg) {
     return TestIsInitialized._writeMessage(
@@ -37098,7 +37098,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Deserializes a TestIsInitialized from protobuf.
+   * Deserializes TestIsInitialized from protobuf.
    */
   decode: function (bytes) {
     return TestIsInitialized._readMessage(
@@ -37108,14 +37108,14 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Serializes a TestIsInitialized to JSON.
+   * Serializes TestIsInitialized to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestIsInitialized._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestIsInitialized from JSON.
+   * Deserializes TestIsInitialized from JSON.
    */
   decodeJSON: function (json) {
     return TestIsInitialized._readMessageJSON(
@@ -37125,7 +37125,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Initializes a TestIsInitialized with all fields set to their default value.
+   * Initializes TestIsInitialized with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37201,35 +37201,35 @@ export const TestIsInitialized = {
 
   SubMessage: {
     /**
-     * Serializes a TestIsInitialized.SubMessage to protobuf.
+     * Serializes TestIsInitialized.SubMessage to protobuf.
      */
     encode: function (_msg) {
       return new Uint8Array();
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from protobuf.
+     * Deserializes TestIsInitialized.SubMessage from protobuf.
      */
     decode: function (_bytes) {
       return {};
     },
 
     /**
-     * Serializes a TestIsInitialized.SubMessage to JSON.
+     * Serializes TestIsInitialized.SubMessage to JSON.
      */
     encodeJSON: function (_msg) {
       return \\"{}\\";
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from JSON.
+     * Deserializes TestIsInitialized.SubMessage from JSON.
      */
     decodeJSON: function (_json) {
       return {};
     },
 
     /**
-     * Initializes a TestIsInitialized.SubMessage with all fields set to their default value.
+     * Initializes TestIsInitialized.SubMessage with all fields set to their default value.
      */
     initialize: function () {
       return {};
@@ -37265,7 +37265,7 @@ export const TestIsInitialized = {
 
     SubGroup: {
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to protobuf.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to protobuf.
        */
       encode: function (msg) {
         return TestIsInitialized.SubMessage.SubGroup._writeMessage(
@@ -37275,7 +37275,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from protobuf.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from protobuf.
        */
       decode: function (bytes) {
         return TestIsInitialized.SubMessage.SubGroup._readMessage(
@@ -37285,7 +37285,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to JSON.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -37294,7 +37294,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from JSON.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from JSON.
        */
       decodeJSON: function (json) {
         return TestIsInitialized.SubMessage.SubGroup._readMessageJSON(
@@ -37304,7 +37304,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Initializes a TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
+       * Initializes TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -37369,7 +37369,7 @@ export const TestIsInitialized = {
 
 export const TestDupFieldNumber = {
   /**
-   * Serializes a TestDupFieldNumber to protobuf.
+   * Serializes TestDupFieldNumber to protobuf.
    */
   encode: function (msg) {
     return TestDupFieldNumber._writeMessage(
@@ -37379,7 +37379,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from protobuf.
+   * Deserializes TestDupFieldNumber from protobuf.
    */
   decode: function (bytes) {
     return TestDupFieldNumber._readMessage(
@@ -37389,14 +37389,14 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Serializes a TestDupFieldNumber to JSON.
+   * Serializes TestDupFieldNumber to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDupFieldNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from JSON.
+   * Deserializes TestDupFieldNumber from JSON.
    */
   decodeJSON: function (json) {
     return TestDupFieldNumber._readMessageJSON(
@@ -37406,7 +37406,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Initializes a TestDupFieldNumber with all fields set to their default value.
+   * Initializes TestDupFieldNumber with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37468,7 +37468,7 @@ export const TestDupFieldNumber = {
 
   Foo: {
     /**
-     * Serializes a TestDupFieldNumber.Foo to protobuf.
+     * Serializes TestDupFieldNumber.Foo to protobuf.
      */
     encode: function (msg) {
       return TestDupFieldNumber.Foo._writeMessage(
@@ -37478,7 +37478,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from protobuf.
+     * Deserializes TestDupFieldNumber.Foo from protobuf.
      */
     decode: function (bytes) {
       return TestDupFieldNumber.Foo._readMessage(
@@ -37488,14 +37488,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Foo to JSON.
+     * Serializes TestDupFieldNumber.Foo to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestDupFieldNumber.Foo._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from JSON.
+     * Deserializes TestDupFieldNumber.Foo from JSON.
      */
     decodeJSON: function (json) {
       return TestDupFieldNumber.Foo._readMessageJSON(
@@ -37505,7 +37505,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Foo with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Foo with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -37568,7 +37568,7 @@ export const TestDupFieldNumber = {
 
   Bar: {
     /**
-     * Serializes a TestDupFieldNumber.Bar to protobuf.
+     * Serializes TestDupFieldNumber.Bar to protobuf.
      */
     encode: function (msg) {
       return TestDupFieldNumber.Bar._writeMessage(
@@ -37578,7 +37578,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from protobuf.
+     * Deserializes TestDupFieldNumber.Bar from protobuf.
      */
     decode: function (bytes) {
       return TestDupFieldNumber.Bar._readMessage(
@@ -37588,14 +37588,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Bar to JSON.
+     * Serializes TestDupFieldNumber.Bar to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestDupFieldNumber.Bar._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from JSON.
+     * Deserializes TestDupFieldNumber.Bar from JSON.
      */
     decodeJSON: function (json) {
       return TestDupFieldNumber.Bar._readMessageJSON(
@@ -37605,7 +37605,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Bar with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Bar with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -37669,7 +37669,7 @@ export const TestDupFieldNumber = {
 
 export const TestEagerMessage = {
   /**
-   * Serializes a TestEagerMessage to protobuf.
+   * Serializes TestEagerMessage to protobuf.
    */
   encode: function (msg) {
     return TestEagerMessage._writeMessage(
@@ -37679,7 +37679,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Deserializes a TestEagerMessage from protobuf.
+   * Deserializes TestEagerMessage from protobuf.
    */
   decode: function (bytes) {
     return TestEagerMessage._readMessage(
@@ -37689,14 +37689,14 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Serializes a TestEagerMessage to JSON.
+   * Serializes TestEagerMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestEagerMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestEagerMessage from JSON.
+   * Deserializes TestEagerMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestEagerMessage._readMessageJSON(
@@ -37706,7 +37706,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Initializes a TestEagerMessage with all fields set to their default value.
+   * Initializes TestEagerMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37774,7 +37774,7 @@ export const TestEagerMessage = {
 
 export const TestLazyMessage = {
   /**
-   * Serializes a TestLazyMessage to protobuf.
+   * Serializes TestLazyMessage to protobuf.
    */
   encode: function (msg) {
     return TestLazyMessage._writeMessage(
@@ -37784,7 +37784,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Deserializes a TestLazyMessage from protobuf.
+   * Deserializes TestLazyMessage from protobuf.
    */
   decode: function (bytes) {
     return TestLazyMessage._readMessage(
@@ -37794,14 +37794,14 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Serializes a TestLazyMessage to JSON.
+   * Serializes TestLazyMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestLazyMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestLazyMessage from JSON.
+   * Deserializes TestLazyMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestLazyMessage._readMessageJSON(
@@ -37811,7 +37811,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Initializes a TestLazyMessage with all fields set to their default value.
+   * Initializes TestLazyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37879,7 +37879,7 @@ export const TestLazyMessage = {
 
 export const TestNestedMessageHasBits = {
   /**
-   * Serializes a TestNestedMessageHasBits to protobuf.
+   * Serializes TestNestedMessageHasBits to protobuf.
    */
   encode: function (msg) {
     return TestNestedMessageHasBits._writeMessage(
@@ -37889,7 +37889,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from protobuf.
+   * Deserializes TestNestedMessageHasBits from protobuf.
    */
   decode: function (bytes) {
     return TestNestedMessageHasBits._readMessage(
@@ -37899,14 +37899,14 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Serializes a TestNestedMessageHasBits to JSON.
+   * Serializes TestNestedMessageHasBits to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestNestedMessageHasBits._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from JSON.
+   * Deserializes TestNestedMessageHasBits from JSON.
    */
   decodeJSON: function (json) {
     return TestNestedMessageHasBits._readMessageJSON(
@@ -37916,7 +37916,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Initializes a TestNestedMessageHasBits with all fields set to their default value.
+   * Initializes TestNestedMessageHasBits with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -37998,7 +37998,7 @@ export const TestNestedMessageHasBits = {
 
   NestedMessage: {
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to protobuf.
+     * Serializes TestNestedMessageHasBits.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestNestedMessageHasBits.NestedMessage._writeMessage(
@@ -38008,7 +38008,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from protobuf.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestNestedMessageHasBits.NestedMessage._readMessage(
@@ -38018,7 +38018,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to JSON.
+     * Serializes TestNestedMessageHasBits.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -38027,7 +38027,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from JSON.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestNestedMessageHasBits.NestedMessage._readMessageJSON(
@@ -38037,7 +38037,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Initializes a TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
+     * Initializes TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -38132,7 +38132,7 @@ export const TestNestedMessageHasBits = {
 
 export const TestCamelCaseFieldNames = {
   /**
-   * Serializes a TestCamelCaseFieldNames to protobuf.
+   * Serializes TestCamelCaseFieldNames to protobuf.
    */
   encode: function (msg) {
     return TestCamelCaseFieldNames._writeMessage(
@@ -38142,7 +38142,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from protobuf.
+   * Deserializes TestCamelCaseFieldNames from protobuf.
    */
   decode: function (bytes) {
     return TestCamelCaseFieldNames._readMessage(
@@ -38152,14 +38152,14 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Serializes a TestCamelCaseFieldNames to JSON.
+   * Serializes TestCamelCaseFieldNames to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestCamelCaseFieldNames._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from JSON.
+   * Deserializes TestCamelCaseFieldNames from JSON.
    */
   decodeJSON: function (json) {
     return TestCamelCaseFieldNames._readMessageJSON(
@@ -38169,7 +38169,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Initializes a TestCamelCaseFieldNames with all fields set to their default value.
+   * Initializes TestCamelCaseFieldNames with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -38417,7 +38417,7 @@ export const TestCamelCaseFieldNames = {
 
 export const TestFieldOrderings = {
   /**
-   * Serializes a TestFieldOrderings to protobuf.
+   * Serializes TestFieldOrderings to protobuf.
    */
   encode: function (msg) {
     return TestFieldOrderings._writeMessage(
@@ -38427,7 +38427,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Deserializes a TestFieldOrderings from protobuf.
+   * Deserializes TestFieldOrderings from protobuf.
    */
   decode: function (bytes) {
     return TestFieldOrderings._readMessage(
@@ -38437,14 +38437,14 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Serializes a TestFieldOrderings to JSON.
+   * Serializes TestFieldOrderings to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestFieldOrderings._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestFieldOrderings from JSON.
+   * Deserializes TestFieldOrderings from JSON.
    */
   decodeJSON: function (json) {
     return TestFieldOrderings._readMessageJSON(
@@ -38454,7 +38454,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Initializes a TestFieldOrderings with all fields set to their default value.
+   * Initializes TestFieldOrderings with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -38580,7 +38580,7 @@ export const TestFieldOrderings = {
 
   NestedMessage: {
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to protobuf.
+     * Serializes TestFieldOrderings.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestFieldOrderings.NestedMessage._writeMessage(
@@ -38590,7 +38590,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from protobuf.
+     * Deserializes TestFieldOrderings.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestFieldOrderings.NestedMessage._readMessage(
@@ -38600,7 +38600,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to JSON.
+     * Serializes TestFieldOrderings.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -38609,7 +38609,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from JSON.
+     * Deserializes TestFieldOrderings.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestFieldOrderings.NestedMessage._readMessageJSON(
@@ -38619,7 +38619,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Initializes a TestFieldOrderings.NestedMessage with all fields set to their default value.
+     * Initializes TestFieldOrderings.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -38698,7 +38698,7 @@ export const TestFieldOrderings = {
 
 export const TestExtensionOrderings1 = {
   /**
-   * Serializes a TestExtensionOrderings1 to protobuf.
+   * Serializes TestExtensionOrderings1 to protobuf.
    */
   encode: function (msg) {
     return TestExtensionOrderings1._writeMessage(
@@ -38708,7 +38708,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from protobuf.
+   * Deserializes TestExtensionOrderings1 from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionOrderings1._readMessage(
@@ -38718,14 +38718,14 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings1 to JSON.
+   * Serializes TestExtensionOrderings1 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionOrderings1._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from JSON.
+   * Deserializes TestExtensionOrderings1 from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionOrderings1._readMessageJSON(
@@ -38735,7 +38735,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings1 with all fields set to their default value.
+   * Initializes TestExtensionOrderings1 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -38798,7 +38798,7 @@ export const TestExtensionOrderings1 = {
 
 export const TestExtensionOrderings2 = {
   /**
-   * Serializes a TestExtensionOrderings2 to protobuf.
+   * Serializes TestExtensionOrderings2 to protobuf.
    */
   encode: function (msg) {
     return TestExtensionOrderings2._writeMessage(
@@ -38808,7 +38808,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from protobuf.
+   * Deserializes TestExtensionOrderings2 from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionOrderings2._readMessage(
@@ -38818,14 +38818,14 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings2 to JSON.
+   * Serializes TestExtensionOrderings2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionOrderings2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from JSON.
+   * Deserializes TestExtensionOrderings2 from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionOrderings2._readMessageJSON(
@@ -38835,7 +38835,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings2 with all fields set to their default value.
+   * Initializes TestExtensionOrderings2 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -38897,7 +38897,7 @@ export const TestExtensionOrderings2 = {
 
   TestExtensionOrderings3: {
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
      */
     encode: function (msg) {
       return TestExtensionOrderings2.TestExtensionOrderings3._writeMessage(
@@ -38907,7 +38907,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
      */
     decode: function (bytes) {
       return TestExtensionOrderings2.TestExtensionOrderings3._readMessage(
@@ -38917,7 +38917,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -38926,7 +38926,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
      */
     decodeJSON: function (json) {
       return TestExtensionOrderings2.TestExtensionOrderings3._readMessageJSON(
@@ -38936,7 +38936,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Initializes a TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
+     * Initializes TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -39000,7 +39000,7 @@ export const TestExtensionOrderings2 = {
 
 export const TestExtremeDefaultValues = {
   /**
-   * Serializes a TestExtremeDefaultValues to protobuf.
+   * Serializes TestExtremeDefaultValues to protobuf.
    */
   encode: function (msg) {
     return TestExtremeDefaultValues._writeMessage(
@@ -39010,7 +39010,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from protobuf.
+   * Deserializes TestExtremeDefaultValues from protobuf.
    */
   decode: function (bytes) {
     return TestExtremeDefaultValues._readMessage(
@@ -39020,14 +39020,14 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Serializes a TestExtremeDefaultValues to JSON.
+   * Serializes TestExtremeDefaultValues to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtremeDefaultValues._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from JSON.
+   * Deserializes TestExtremeDefaultValues from JSON.
    */
   decodeJSON: function (json) {
     return TestExtremeDefaultValues._readMessageJSON(
@@ -39037,7 +39037,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Initializes a TestExtremeDefaultValues with all fields set to their default value.
+   * Initializes TestExtremeDefaultValues with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39493,7 +39493,7 @@ export const TestExtremeDefaultValues = {
 
 export const SparseEnumMessage = {
   /**
-   * Serializes a SparseEnumMessage to protobuf.
+   * Serializes SparseEnumMessage to protobuf.
    */
   encode: function (msg) {
     return SparseEnumMessage._writeMessage(
@@ -39503,7 +39503,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Deserializes a SparseEnumMessage from protobuf.
+   * Deserializes SparseEnumMessage from protobuf.
    */
   decode: function (bytes) {
     return SparseEnumMessage._readMessage(
@@ -39513,14 +39513,14 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Serializes a SparseEnumMessage to JSON.
+   * Serializes SparseEnumMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(SparseEnumMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SparseEnumMessage from JSON.
+   * Deserializes SparseEnumMessage from JSON.
    */
   decodeJSON: function (json) {
     return SparseEnumMessage._readMessageJSON(
@@ -39530,7 +39530,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Initializes a SparseEnumMessage with all fields set to their default value.
+   * Initializes SparseEnumMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39593,14 +39593,14 @@ export const SparseEnumMessage = {
 
 export const OneString = {
   /**
-   * Serializes a OneString to protobuf.
+   * Serializes OneString to protobuf.
    */
   encode: function (msg) {
     return OneString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneString from protobuf.
+   * Deserializes OneString from protobuf.
    */
   decode: function (bytes) {
     return OneString._readMessage(
@@ -39610,21 +39610,21 @@ export const OneString = {
   },
 
   /**
-   * Serializes a OneString to JSON.
+   * Serializes OneString to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneString from JSON.
+   * Deserializes OneString from JSON.
    */
   decodeJSON: function (json) {
     return OneString._readMessageJSON(OneString.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneString with all fields set to their default value.
+   * Initializes OneString with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39687,14 +39687,14 @@ export const OneString = {
 
 export const MoreString = {
   /**
-   * Serializes a MoreString to protobuf.
+   * Serializes MoreString to protobuf.
    */
   encode: function (msg) {
     return MoreString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreString from protobuf.
+   * Deserializes MoreString from protobuf.
    */
   decode: function (bytes) {
     return MoreString._readMessage(
@@ -39704,14 +39704,14 @@ export const MoreString = {
   },
 
   /**
-   * Serializes a MoreString to JSON.
+   * Serializes MoreString to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MoreString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreString from JSON.
+   * Deserializes MoreString from JSON.
    */
   decodeJSON: function (json) {
     return MoreString._readMessageJSON(
@@ -39721,7 +39721,7 @@ export const MoreString = {
   },
 
   /**
-   * Initializes a MoreString with all fields set to their default value.
+   * Initializes MoreString with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39784,14 +39784,14 @@ export const MoreString = {
 
 export const OneBytes = {
   /**
-   * Serializes a OneBytes to protobuf.
+   * Serializes OneBytes to protobuf.
    */
   encode: function (msg) {
     return OneBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneBytes from protobuf.
+   * Deserializes OneBytes from protobuf.
    */
   decode: function (bytes) {
     return OneBytes._readMessage(
@@ -39801,21 +39801,21 @@ export const OneBytes = {
   },
 
   /**
-   * Serializes a OneBytes to JSON.
+   * Serializes OneBytes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneBytes from JSON.
+   * Deserializes OneBytes from JSON.
    */
   decodeJSON: function (json) {
     return OneBytes._readMessageJSON(OneBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneBytes with all fields set to their default value.
+   * Initializes OneBytes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39878,14 +39878,14 @@ export const OneBytes = {
 
 export const MoreBytes = {
   /**
-   * Serializes a MoreBytes to protobuf.
+   * Serializes MoreBytes to protobuf.
    */
   encode: function (msg) {
     return MoreBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreBytes from protobuf.
+   * Deserializes MoreBytes from protobuf.
    */
   decode: function (bytes) {
     return MoreBytes._readMessage(
@@ -39895,21 +39895,21 @@ export const MoreBytes = {
   },
 
   /**
-   * Serializes a MoreBytes to JSON.
+   * Serializes MoreBytes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MoreBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreBytes from JSON.
+   * Deserializes MoreBytes from JSON.
    */
   decodeJSON: function (json) {
     return MoreBytes._readMessageJSON(MoreBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a MoreBytes with all fields set to their default value.
+   * Initializes MoreBytes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -39972,7 +39972,7 @@ export const MoreBytes = {
 
 export const Int32Message = {
   /**
-   * Serializes a Int32Message to protobuf.
+   * Serializes Int32Message to protobuf.
    */
   encode: function (msg) {
     return Int32Message._writeMessage(
@@ -39982,7 +39982,7 @@ export const Int32Message = {
   },
 
   /**
-   * Deserializes a Int32Message from protobuf.
+   * Deserializes Int32Message from protobuf.
    */
   decode: function (bytes) {
     return Int32Message._readMessage(
@@ -39992,14 +39992,14 @@ export const Int32Message = {
   },
 
   /**
-   * Serializes a Int32Message to JSON.
+   * Serializes Int32Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Message from JSON.
+   * Deserializes Int32Message from JSON.
    */
   decodeJSON: function (json) {
     return Int32Message._readMessageJSON(
@@ -40009,7 +40009,7 @@ export const Int32Message = {
   },
 
   /**
-   * Initializes a Int32Message with all fields set to their default value.
+   * Initializes Int32Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40072,7 +40072,7 @@ export const Int32Message = {
 
 export const Uint32Message = {
   /**
-   * Serializes a Uint32Message to protobuf.
+   * Serializes Uint32Message to protobuf.
    */
   encode: function (msg) {
     return Uint32Message._writeMessage(
@@ -40082,7 +40082,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Deserializes a Uint32Message from protobuf.
+   * Deserializes Uint32Message from protobuf.
    */
   decode: function (bytes) {
     return Uint32Message._readMessage(
@@ -40092,14 +40092,14 @@ export const Uint32Message = {
   },
 
   /**
-   * Serializes a Uint32Message to JSON.
+   * Serializes Uint32Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Uint32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint32Message from JSON.
+   * Deserializes Uint32Message from JSON.
    */
   decodeJSON: function (json) {
     return Uint32Message._readMessageJSON(
@@ -40109,7 +40109,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Initializes a Uint32Message with all fields set to their default value.
+   * Initializes Uint32Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40172,7 +40172,7 @@ export const Uint32Message = {
 
 export const Int64Message = {
   /**
-   * Serializes a Int64Message to protobuf.
+   * Serializes Int64Message to protobuf.
    */
   encode: function (msg) {
     return Int64Message._writeMessage(
@@ -40182,7 +40182,7 @@ export const Int64Message = {
   },
 
   /**
-   * Deserializes a Int64Message from protobuf.
+   * Deserializes Int64Message from protobuf.
    */
   decode: function (bytes) {
     return Int64Message._readMessage(
@@ -40192,14 +40192,14 @@ export const Int64Message = {
   },
 
   /**
-   * Serializes a Int64Message to JSON.
+   * Serializes Int64Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Message from JSON.
+   * Deserializes Int64Message from JSON.
    */
   decodeJSON: function (json) {
     return Int64Message._readMessageJSON(
@@ -40209,7 +40209,7 @@ export const Int64Message = {
   },
 
   /**
-   * Initializes a Int64Message with all fields set to their default value.
+   * Initializes Int64Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40272,7 +40272,7 @@ export const Int64Message = {
 
 export const Uint64Message = {
   /**
-   * Serializes a Uint64Message to protobuf.
+   * Serializes Uint64Message to protobuf.
    */
   encode: function (msg) {
     return Uint64Message._writeMessage(
@@ -40282,7 +40282,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Deserializes a Uint64Message from protobuf.
+   * Deserializes Uint64Message from protobuf.
    */
   decode: function (bytes) {
     return Uint64Message._readMessage(
@@ -40292,14 +40292,14 @@ export const Uint64Message = {
   },
 
   /**
-   * Serializes a Uint64Message to JSON.
+   * Serializes Uint64Message to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Uint64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint64Message from JSON.
+   * Deserializes Uint64Message from JSON.
    */
   decodeJSON: function (json) {
     return Uint64Message._readMessageJSON(
@@ -40309,7 +40309,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Initializes a Uint64Message with all fields set to their default value.
+   * Initializes Uint64Message with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40372,14 +40372,14 @@ export const Uint64Message = {
 
 export const BoolMessage = {
   /**
-   * Serializes a BoolMessage to protobuf.
+   * Serializes BoolMessage to protobuf.
    */
   encode: function (msg) {
     return BoolMessage._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolMessage from protobuf.
+   * Deserializes BoolMessage from protobuf.
    */
   decode: function (bytes) {
     return BoolMessage._readMessage(
@@ -40389,14 +40389,14 @@ export const BoolMessage = {
   },
 
   /**
-   * Serializes a BoolMessage to JSON.
+   * Serializes BoolMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BoolMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolMessage from JSON.
+   * Deserializes BoolMessage from JSON.
    */
   decodeJSON: function (json) {
     return BoolMessage._readMessageJSON(
@@ -40406,7 +40406,7 @@ export const BoolMessage = {
   },
 
   /**
-   * Initializes a BoolMessage with all fields set to their default value.
+   * Initializes BoolMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40469,14 +40469,14 @@ export const BoolMessage = {
 
 export const TestOneof = {
   /**
-   * Serializes a TestOneof to protobuf.
+   * Serializes TestOneof to protobuf.
    */
   encode: function (msg) {
     return TestOneof._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof from protobuf.
+   * Deserializes TestOneof from protobuf.
    */
   decode: function (bytes) {
     return TestOneof._readMessage(
@@ -40486,21 +40486,21 @@ export const TestOneof = {
   },
 
   /**
-   * Serializes a TestOneof to JSON.
+   * Serializes TestOneof to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof from JSON.
+   * Deserializes TestOneof from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof._readMessageJSON(TestOneof.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestOneof with all fields set to their default value.
+   * Initializes TestOneof with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40595,7 +40595,7 @@ export const TestOneof = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof.FooGroup to protobuf.
+     * Serializes TestOneof.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneof.FooGroup._writeMessage(
@@ -40605,7 +40605,7 @@ export const TestOneof = {
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from protobuf.
+     * Deserializes TestOneof.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneof.FooGroup._readMessage(
@@ -40615,14 +40615,14 @@ export const TestOneof = {
     },
 
     /**
-     * Serializes a TestOneof.FooGroup to JSON.
+     * Serializes TestOneof.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from JSON.
+     * Deserializes TestOneof.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof.FooGroup._readMessageJSON(
@@ -40632,7 +40632,7 @@ export const TestOneof = {
     },
 
     /**
-     * Initializes a TestOneof.FooGroup with all fields set to their default value.
+     * Initializes TestOneof.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -40711,7 +40711,7 @@ export const TestOneof = {
 
 export const TestOneofBackwardsCompatible = {
   /**
-   * Serializes a TestOneofBackwardsCompatible to protobuf.
+   * Serializes TestOneofBackwardsCompatible to protobuf.
    */
   encode: function (msg) {
     return TestOneofBackwardsCompatible._writeMessage(
@@ -40721,7 +40721,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from protobuf.
+   * Deserializes TestOneofBackwardsCompatible from protobuf.
    */
   decode: function (bytes) {
     return TestOneofBackwardsCompatible._readMessage(
@@ -40731,14 +40731,14 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Serializes a TestOneofBackwardsCompatible to JSON.
+   * Serializes TestOneofBackwardsCompatible to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneofBackwardsCompatible._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from JSON.
+   * Deserializes TestOneofBackwardsCompatible from JSON.
    */
   decodeJSON: function (json) {
     return TestOneofBackwardsCompatible._readMessageJSON(
@@ -40748,7 +40748,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Initializes a TestOneofBackwardsCompatible with all fields set to their default value.
+   * Initializes TestOneofBackwardsCompatible with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -40845,7 +40845,7 @@ export const TestOneofBackwardsCompatible = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to protobuf.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneofBackwardsCompatible.FooGroup._writeMessage(
@@ -40855,7 +40855,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from protobuf.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneofBackwardsCompatible.FooGroup._readMessage(
@@ -40865,7 +40865,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to JSON.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -40874,7 +40874,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from JSON.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneofBackwardsCompatible.FooGroup._readMessageJSON(
@@ -40884,7 +40884,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Initializes a TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
+     * Initializes TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -40963,14 +40963,14 @@ export const TestOneofBackwardsCompatible = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg) {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes) {
     return TestOneof2._readMessage(
@@ -40980,14 +40980,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof2._readMessageJSON(
@@ -40997,7 +40997,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -41411,7 +41411,7 @@ export const TestOneof2 = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof2.FooGroup to protobuf.
+     * Serializes TestOneof2.FooGroup to protobuf.
      */
     encode: function (msg) {
       return TestOneof2.FooGroup._writeMessage(
@@ -41421,7 +41421,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from protobuf.
+     * Deserializes TestOneof2.FooGroup from protobuf.
      */
     decode: function (bytes) {
       return TestOneof2.FooGroup._readMessage(
@@ -41431,14 +41431,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.FooGroup to JSON.
+     * Serializes TestOneof2.FooGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof2.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from JSON.
+     * Deserializes TestOneof2.FooGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof2.FooGroup._readMessageJSON(
@@ -41448,7 +41448,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.FooGroup with all fields set to their default value.
+     * Initializes TestOneof2.FooGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -41526,7 +41526,7 @@ export const TestOneof2 = {
 
   NestedMessage: {
     /**
-     * Serializes a TestOneof2.NestedMessage to protobuf.
+     * Serializes TestOneof2.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestOneof2.NestedMessage._writeMessage(
@@ -41536,7 +41536,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from protobuf.
+     * Deserializes TestOneof2.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestOneof2.NestedMessage._readMessage(
@@ -41546,14 +41546,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.NestedMessage to JSON.
+     * Serializes TestOneof2.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestOneof2.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from JSON.
+     * Deserializes TestOneof2.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestOneof2.NestedMessage._readMessageJSON(
@@ -41563,7 +41563,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.NestedMessage with all fields set to their default value.
+     * Initializes TestOneof2.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -41642,7 +41642,7 @@ export const TestOneof2 = {
 
 export const TestRequiredOneof = {
   /**
-   * Serializes a TestRequiredOneof to protobuf.
+   * Serializes TestRequiredOneof to protobuf.
    */
   encode: function (msg) {
     return TestRequiredOneof._writeMessage(
@@ -41652,7 +41652,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Deserializes a TestRequiredOneof from protobuf.
+   * Deserializes TestRequiredOneof from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredOneof._readMessage(
@@ -41662,14 +41662,14 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Serializes a TestRequiredOneof to JSON.
+   * Serializes TestRequiredOneof to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredOneof from JSON.
+   * Deserializes TestRequiredOneof from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredOneof._readMessageJSON(
@@ -41679,7 +41679,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Initializes a TestRequiredOneof with all fields set to their default value.
+   * Initializes TestRequiredOneof with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -41783,7 +41783,7 @@ export const TestRequiredOneof = {
 
   NestedMessage: {
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to protobuf.
+     * Serializes TestRequiredOneof.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestRequiredOneof.NestedMessage._writeMessage(
@@ -41793,7 +41793,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from protobuf.
+     * Deserializes TestRequiredOneof.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestRequiredOneof.NestedMessage._readMessage(
@@ -41803,7 +41803,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to JSON.
+     * Serializes TestRequiredOneof.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -41812,7 +41812,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from JSON.
+     * Deserializes TestRequiredOneof.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestRequiredOneof.NestedMessage._readMessageJSON(
@@ -41822,7 +41822,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Initializes a TestRequiredOneof.NestedMessage with all fields set to their default value.
+     * Initializes TestRequiredOneof.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -41886,7 +41886,7 @@ export const TestRequiredOneof = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestPackedTypes._writeMessage(
@@ -41896,7 +41896,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestPackedTypes._readMessage(
@@ -41906,14 +41906,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestPackedTypes._readMessageJSON(
@@ -41923,7 +41923,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -42196,7 +42196,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestUnpackedTypes._writeMessage(
@@ -42206,7 +42206,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestUnpackedTypes._readMessage(
@@ -42216,14 +42216,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestUnpackedTypes._readMessageJSON(
@@ -42233,7 +42233,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -42506,35 +42506,35 @@ export const TestUnpackedTypes = {
 
 export const TestPackedExtensions = {
   /**
-   * Serializes a TestPackedExtensions to protobuf.
+   * Serializes TestPackedExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPackedExtensions from protobuf.
+   * Deserializes TestPackedExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestPackedExtensions to JSON.
+   * Serializes TestPackedExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPackedExtensions from JSON.
+   * Deserializes TestPackedExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestPackedExtensions with all fields set to their default value.
+   * Initializes TestPackedExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -42571,35 +42571,35 @@ export const TestPackedExtensions = {
 
 export const TestUnpackedExtensions = {
   /**
-   * Serializes a TestUnpackedExtensions to protobuf.
+   * Serializes TestUnpackedExtensions to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from protobuf.
+   * Deserializes TestUnpackedExtensions from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestUnpackedExtensions to JSON.
+   * Serializes TestUnpackedExtensions to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from JSON.
+   * Deserializes TestUnpackedExtensions from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestUnpackedExtensions with all fields set to their default value.
+   * Initializes TestUnpackedExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -42636,7 +42636,7 @@ export const TestUnpackedExtensions = {
 
 export const TestDynamicExtensions = {
   /**
-   * Serializes a TestDynamicExtensions to protobuf.
+   * Serializes TestDynamicExtensions to protobuf.
    */
   encode: function (msg) {
     return TestDynamicExtensions._writeMessage(
@@ -42646,7 +42646,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from protobuf.
+   * Deserializes TestDynamicExtensions from protobuf.
    */
   decode: function (bytes) {
     return TestDynamicExtensions._readMessage(
@@ -42656,14 +42656,14 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Serializes a TestDynamicExtensions to JSON.
+   * Serializes TestDynamicExtensions to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestDynamicExtensions._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from JSON.
+   * Deserializes TestDynamicExtensions from JSON.
    */
   decodeJSON: function (json) {
     return TestDynamicExtensions._readMessageJSON(
@@ -42673,7 +42673,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Initializes a TestDynamicExtensions with all fields set to their default value.
+   * Initializes TestDynamicExtensions with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -42914,7 +42914,7 @@ export const TestDynamicExtensions = {
 
   DynamicMessageType: {
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to protobuf.
+     * Serializes TestDynamicExtensions.DynamicMessageType to protobuf.
      */
     encode: function (msg) {
       return TestDynamicExtensions.DynamicMessageType._writeMessage(
@@ -42924,7 +42924,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from protobuf.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from protobuf.
      */
     decode: function (bytes) {
       return TestDynamicExtensions.DynamicMessageType._readMessage(
@@ -42934,7 +42934,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to JSON.
+     * Serializes TestDynamicExtensions.DynamicMessageType to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -42943,7 +42943,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from JSON.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from JSON.
      */
     decodeJSON: function (json) {
       return TestDynamicExtensions.DynamicMessageType._readMessageJSON(
@@ -42953,7 +42953,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Initializes a TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
+     * Initializes TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -43017,7 +43017,7 @@ export const TestDynamicExtensions = {
 
 export const TestRepeatedScalarDifferentTagSizes = {
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to protobuf.
+   * Serializes TestRepeatedScalarDifferentTagSizes to protobuf.
    */
   encode: function (msg) {
     return TestRepeatedScalarDifferentTagSizes._writeMessage(
@@ -43027,7 +43027,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from protobuf.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from protobuf.
    */
   decode: function (bytes) {
     return TestRepeatedScalarDifferentTagSizes._readMessage(
@@ -43037,7 +43037,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to JSON.
+   * Serializes TestRepeatedScalarDifferentTagSizes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(
@@ -43046,7 +43046,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from JSON.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from JSON.
    */
   decodeJSON: function (json) {
     return TestRepeatedScalarDifferentTagSizes._readMessageJSON(
@@ -43056,7 +43056,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Initializes a TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
+   * Initializes TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -43203,7 +43203,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
 
 export const TestParsingMerge = {
   /**
-   * Serializes a TestParsingMerge to protobuf.
+   * Serializes TestParsingMerge to protobuf.
    */
   encode: function (msg) {
     return TestParsingMerge._writeMessage(
@@ -43213,7 +43213,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Deserializes a TestParsingMerge from protobuf.
+   * Deserializes TestParsingMerge from protobuf.
    */
   decode: function (bytes) {
     return TestParsingMerge._readMessage(
@@ -43223,14 +43223,14 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Serializes a TestParsingMerge to JSON.
+   * Serializes TestParsingMerge to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestParsingMerge._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestParsingMerge from JSON.
+   * Deserializes TestParsingMerge from JSON.
    */
   decodeJSON: function (json) {
     return TestParsingMerge._readMessageJSON(
@@ -43240,7 +43240,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Initializes a TestParsingMerge with all fields set to their default value.
+   * Initializes TestParsingMerge with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -43358,7 +43358,7 @@ export const TestParsingMerge = {
 
   RepeatedFieldsGenerator: {
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to protobuf.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.RepeatedFieldsGenerator._writeMessage(
@@ -43368,7 +43368,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from protobuf.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.RepeatedFieldsGenerator._readMessage(
@@ -43378,7 +43378,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to JSON.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -43387,7 +43387,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from JSON.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.RepeatedFieldsGenerator._readMessageJSON(
@@ -43397,7 +43397,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -43549,7 +43549,7 @@ export const TestParsingMerge = {
 
     Group1: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
        */
       encode: function (msg) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._writeMessage(
@@ -43559,7 +43559,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
        */
       decode: function (bytes) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._readMessage(
@@ -43569,7 +43569,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -43578,7 +43578,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
        */
       decodeJSON: function (json) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group1._readMessageJSON(
@@ -43588,7 +43588,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -43656,7 +43656,7 @@ export const TestParsingMerge = {
 
     Group2: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
        */
       encode: function (msg) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._writeMessage(
@@ -43666,7 +43666,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
        */
       decode: function (bytes) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._readMessage(
@@ -43676,7 +43676,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
        */
       encodeJSON: function (msg) {
         return JSON.stringify(
@@ -43685,7 +43685,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
        */
       decodeJSON: function (json) {
         return TestParsingMerge.RepeatedFieldsGenerator.Group2._readMessageJSON(
@@ -43695,7 +43695,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
        */
       initialize: function () {
         return {
@@ -43764,7 +43764,7 @@ export const TestParsingMerge = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to protobuf.
+     * Serializes TestParsingMerge.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.OptionalGroup._writeMessage(
@@ -43774,7 +43774,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from protobuf.
+     * Deserializes TestParsingMerge.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.OptionalGroup._readMessage(
@@ -43784,7 +43784,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to JSON.
+     * Serializes TestParsingMerge.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -43793,7 +43793,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from JSON.
+     * Deserializes TestParsingMerge.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.OptionalGroup._readMessageJSON(
@@ -43803,7 +43803,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.OptionalGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -43881,7 +43881,7 @@ export const TestParsingMerge = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to protobuf.
+     * Serializes TestParsingMerge.RepeatedGroup to protobuf.
      */
     encode: function (msg) {
       return TestParsingMerge.RepeatedGroup._writeMessage(
@@ -43891,7 +43891,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from protobuf.
+     * Deserializes TestParsingMerge.RepeatedGroup from protobuf.
      */
     decode: function (bytes) {
       return TestParsingMerge.RepeatedGroup._readMessage(
@@ -43901,7 +43901,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to JSON.
+     * Serializes TestParsingMerge.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -43910,7 +43910,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from JSON.
+     * Deserializes TestParsingMerge.RepeatedGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestParsingMerge.RepeatedGroup._readMessageJSON(
@@ -43920,7 +43920,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -43999,7 +43999,7 @@ export const TestParsingMerge = {
 
 export const TestCommentInjectionMessage = {
   /**
-   * Serializes a TestCommentInjectionMessage to protobuf.
+   * Serializes TestCommentInjectionMessage to protobuf.
    */
   encode: function (msg) {
     return TestCommentInjectionMessage._writeMessage(
@@ -44009,7 +44009,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from protobuf.
+   * Deserializes TestCommentInjectionMessage from protobuf.
    */
   decode: function (bytes) {
     return TestCommentInjectionMessage._readMessage(
@@ -44019,14 +44019,14 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Serializes a TestCommentInjectionMessage to JSON.
+   * Serializes TestCommentInjectionMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestCommentInjectionMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from JSON.
+   * Deserializes TestCommentInjectionMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestCommentInjectionMessage._readMessageJSON(
@@ -44036,7 +44036,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Initializes a TestCommentInjectionMessage with all fields set to their default value.
+   * Initializes TestCommentInjectionMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -44099,35 +44099,35 @@ export const TestCommentInjectionMessage = {
 
 export const FooRequest = {
   /**
-   * Serializes a FooRequest to protobuf.
+   * Serializes FooRequest to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooRequest from protobuf.
+   * Deserializes FooRequest from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooRequest to JSON.
+   * Serializes FooRequest to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooRequest from JSON.
+   * Deserializes FooRequest from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooRequest with all fields set to their default value.
+   * Initializes FooRequest with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44164,35 +44164,35 @@ export const FooRequest = {
 
 export const FooResponse = {
   /**
-   * Serializes a FooResponse to protobuf.
+   * Serializes FooResponse to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooResponse from protobuf.
+   * Deserializes FooResponse from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooResponse to JSON.
+   * Serializes FooResponse to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooResponse from JSON.
+   * Deserializes FooResponse from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooResponse with all fields set to their default value.
+   * Initializes FooResponse with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44229,35 +44229,35 @@ export const FooResponse = {
 
 export const FooClientMessage = {
   /**
-   * Serializes a FooClientMessage to protobuf.
+   * Serializes FooClientMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooClientMessage from protobuf.
+   * Deserializes FooClientMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooClientMessage to JSON.
+   * Serializes FooClientMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooClientMessage from JSON.
+   * Deserializes FooClientMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooClientMessage with all fields set to their default value.
+   * Initializes FooClientMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44294,35 +44294,35 @@ export const FooClientMessage = {
 
 export const FooServerMessage = {
   /**
-   * Serializes a FooServerMessage to protobuf.
+   * Serializes FooServerMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooServerMessage from protobuf.
+   * Deserializes FooServerMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a FooServerMessage to JSON.
+   * Serializes FooServerMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooServerMessage from JSON.
+   * Deserializes FooServerMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a FooServerMessage with all fields set to their default value.
+   * Initializes FooServerMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44359,35 +44359,35 @@ export const FooServerMessage = {
 
 export const BarRequest = {
   /**
-   * Serializes a BarRequest to protobuf.
+   * Serializes BarRequest to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarRequest from protobuf.
+   * Deserializes BarRequest from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a BarRequest to JSON.
+   * Serializes BarRequest to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarRequest from JSON.
+   * Deserializes BarRequest from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a BarRequest with all fields set to their default value.
+   * Initializes BarRequest with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44424,35 +44424,35 @@ export const BarRequest = {
 
 export const BarResponse = {
   /**
-   * Serializes a BarResponse to protobuf.
+   * Serializes BarResponse to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarResponse from protobuf.
+   * Deserializes BarResponse from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a BarResponse to JSON.
+   * Serializes BarResponse to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarResponse from JSON.
+   * Deserializes BarResponse from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a BarResponse with all fields set to their default value.
+   * Initializes BarResponse with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -44489,7 +44489,7 @@ export const BarResponse = {
 
 export const TestJsonName = {
   /**
-   * Serializes a TestJsonName to protobuf.
+   * Serializes TestJsonName to protobuf.
    */
   encode: function (msg) {
     return TestJsonName._writeMessage(
@@ -44499,7 +44499,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Deserializes a TestJsonName from protobuf.
+   * Deserializes TestJsonName from protobuf.
    */
   decode: function (bytes) {
     return TestJsonName._readMessage(
@@ -44509,14 +44509,14 @@ export const TestJsonName = {
   },
 
   /**
-   * Serializes a TestJsonName to JSON.
+   * Serializes TestJsonName to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestJsonName._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestJsonName from JSON.
+   * Deserializes TestJsonName from JSON.
    */
   decodeJSON: function (json) {
     return TestJsonName._readMessageJSON(
@@ -44526,7 +44526,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Initializes a TestJsonName with all fields set to their default value.
+   * Initializes TestJsonName with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -44679,7 +44679,7 @@ export const TestJsonName = {
 
 export const TestHugeFieldNumbers = {
   /**
-   * Serializes a TestHugeFieldNumbers to protobuf.
+   * Serializes TestHugeFieldNumbers to protobuf.
    */
   encode: function (msg) {
     return TestHugeFieldNumbers._writeMessage(
@@ -44689,7 +44689,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from protobuf.
+   * Deserializes TestHugeFieldNumbers from protobuf.
    */
   decode: function (bytes) {
     return TestHugeFieldNumbers._readMessage(
@@ -44699,14 +44699,14 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Serializes a TestHugeFieldNumbers to JSON.
+   * Serializes TestHugeFieldNumbers to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestHugeFieldNumbers._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from JSON.
+   * Deserializes TestHugeFieldNumbers from JSON.
    */
   decodeJSON: function (json) {
     return TestHugeFieldNumbers._readMessageJSON(
@@ -44716,7 +44716,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Initializes a TestHugeFieldNumbers with all fields set to their default value.
+   * Initializes TestHugeFieldNumbers with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -45003,7 +45003,7 @@ export const TestHugeFieldNumbers = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to protobuf.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to protobuf.
      */
     encode: function (msg) {
       return TestHugeFieldNumbers.OptionalGroup._writeMessage(
@@ -45013,7 +45013,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from protobuf.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from protobuf.
      */
     decode: function (bytes) {
       return TestHugeFieldNumbers.OptionalGroup._readMessage(
@@ -45023,7 +45023,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to JSON.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(
@@ -45032,7 +45032,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from JSON.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from JSON.
      */
     decodeJSON: function (json) {
       return TestHugeFieldNumbers.OptionalGroup._readMessageJSON(
@@ -45042,7 +45042,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Initializes a TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
+     * Initializes TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -45174,7 +45174,7 @@ export const TestHugeFieldNumbers = {
 
 export const TestExtensionInsideTable = {
   /**
-   * Serializes a TestExtensionInsideTable to protobuf.
+   * Serializes TestExtensionInsideTable to protobuf.
    */
   encode: function (msg) {
     return TestExtensionInsideTable._writeMessage(
@@ -45184,7 +45184,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from protobuf.
+   * Deserializes TestExtensionInsideTable from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionInsideTable._readMessage(
@@ -45194,14 +45194,14 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Serializes a TestExtensionInsideTable to JSON.
+   * Serializes TestExtensionInsideTable to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionInsideTable._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from JSON.
+   * Deserializes TestExtensionInsideTable from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionInsideTable._readMessageJSON(
@@ -45211,7 +45211,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Initializes a TestExtensionInsideTable with all fields set to their default value.
+   * Initializes TestExtensionInsideTable with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -45394,7 +45394,7 @@ export const TestExtensionInsideTable = {
 
 export const TestExtensionRangeSerialize = {
   /**
-   * Serializes a TestExtensionRangeSerialize to protobuf.
+   * Serializes TestExtensionRangeSerialize to protobuf.
    */
   encode: function (msg) {
     return TestExtensionRangeSerialize._writeMessage(
@@ -45404,7 +45404,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from protobuf.
+   * Deserializes TestExtensionRangeSerialize from protobuf.
    */
   decode: function (bytes) {
     return TestExtensionRangeSerialize._readMessage(
@@ -45414,14 +45414,14 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Serializes a TestExtensionRangeSerialize to JSON.
+   * Serializes TestExtensionRangeSerialize to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestExtensionRangeSerialize._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from JSON.
+   * Deserializes TestExtensionRangeSerialize from JSON.
    */
   decodeJSON: function (json) {
     return TestExtensionRangeSerialize._readMessageJSON(
@@ -45431,7 +45431,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Initializes a TestExtensionRangeSerialize with all fields set to their default value.
+   * Initializes TestExtensionRangeSerialize with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -45624,35 +45624,35 @@ export const MapEnum = {
 
 export const TestMap = {
   /**
-   * Serializes a TestMap to protobuf.
+   * Serializes TestMap to protobuf.
    */
   encode: function (msg) {
     return TestMap._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestMap from protobuf.
+   * Deserializes TestMap from protobuf.
    */
   decode: function (bytes) {
     return TestMap._readMessage(TestMap.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a TestMap to JSON.
+   * Serializes TestMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMap from JSON.
+   * Deserializes TestMap from JSON.
    */
   decodeJSON: function (json) {
     return TestMap._readMessageJSON(TestMap.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestMap with all fields set to their default value.
+   * Initializes TestMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -47770,7 +47770,7 @@ export const TestMap = {
 
 export const TestMapSubmessage = {
   /**
-   * Serializes a TestMapSubmessage to protobuf.
+   * Serializes TestMapSubmessage to protobuf.
    */
   encode: function (msg) {
     return TestMapSubmessage._writeMessage(
@@ -47780,7 +47780,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Deserializes a TestMapSubmessage from protobuf.
+   * Deserializes TestMapSubmessage from protobuf.
    */
   decode: function (bytes) {
     return TestMapSubmessage._readMessage(
@@ -47790,14 +47790,14 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Serializes a TestMapSubmessage to JSON.
+   * Serializes TestMapSubmessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMapSubmessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMapSubmessage from JSON.
+   * Deserializes TestMapSubmessage from JSON.
    */
   decodeJSON: function (json) {
     return TestMapSubmessage._readMessageJSON(
@@ -47807,7 +47807,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Initializes a TestMapSubmessage with all fields set to their default value.
+   * Initializes TestMapSubmessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -47875,7 +47875,7 @@ export const TestMapSubmessage = {
 
 export const TestMessageMap = {
   /**
-   * Serializes a TestMessageMap to protobuf.
+   * Serializes TestMessageMap to protobuf.
    */
   encode: function (msg) {
     return TestMessageMap._writeMessage(
@@ -47885,7 +47885,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Deserializes a TestMessageMap from protobuf.
+   * Deserializes TestMessageMap from protobuf.
    */
   decode: function (bytes) {
     return TestMessageMap._readMessage(
@@ -47895,14 +47895,14 @@ export const TestMessageMap = {
   },
 
   /**
-   * Serializes a TestMessageMap to JSON.
+   * Serializes TestMessageMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageMap from JSON.
+   * Deserializes TestMessageMap from JSON.
    */
   decodeJSON: function (json) {
     return TestMessageMap._readMessageJSON(
@@ -47912,7 +47912,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Initializes a TestMessageMap with all fields set to their default value.
+   * Initializes TestMessageMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -48076,7 +48076,7 @@ export const TestMessageMap = {
 
 export const TestSameTypeMap = {
   /**
-   * Serializes a TestSameTypeMap to protobuf.
+   * Serializes TestSameTypeMap to protobuf.
    */
   encode: function (msg) {
     return TestSameTypeMap._writeMessage(
@@ -48086,7 +48086,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Deserializes a TestSameTypeMap from protobuf.
+   * Deserializes TestSameTypeMap from protobuf.
    */
   decode: function (bytes) {
     return TestSameTypeMap._readMessage(
@@ -48096,14 +48096,14 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Serializes a TestSameTypeMap to JSON.
+   * Serializes TestSameTypeMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestSameTypeMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestSameTypeMap from JSON.
+   * Deserializes TestSameTypeMap from JSON.
    */
   decodeJSON: function (json) {
     return TestSameTypeMap._readMessageJSON(
@@ -48113,7 +48113,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Initializes a TestSameTypeMap with all fields set to their default value.
+   * Initializes TestSameTypeMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -48371,7 +48371,7 @@ export const TestSameTypeMap = {
 
 export const TestRequiredMessageMap = {
   /**
-   * Serializes a TestRequiredMessageMap to protobuf.
+   * Serializes TestRequiredMessageMap to protobuf.
    */
   encode: function (msg) {
     return TestRequiredMessageMap._writeMessage(
@@ -48381,7 +48381,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from protobuf.
+   * Deserializes TestRequiredMessageMap from protobuf.
    */
   decode: function (bytes) {
     return TestRequiredMessageMap._readMessage(
@@ -48391,14 +48391,14 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Serializes a TestRequiredMessageMap to JSON.
+   * Serializes TestRequiredMessageMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRequiredMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from JSON.
+   * Deserializes TestRequiredMessageMap from JSON.
    */
   decodeJSON: function (json) {
     return TestRequiredMessageMap._readMessageJSON(
@@ -48408,7 +48408,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Initializes a TestRequiredMessageMap with all fields set to their default value.
+   * Initializes TestRequiredMessageMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -48572,7 +48572,7 @@ export const TestRequiredMessageMap = {
 
 export const TestArenaMap = {
   /**
-   * Serializes a TestArenaMap to protobuf.
+   * Serializes TestArenaMap to protobuf.
    */
   encode: function (msg) {
     return TestArenaMap._writeMessage(
@@ -48582,7 +48582,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Deserializes a TestArenaMap from protobuf.
+   * Deserializes TestArenaMap from protobuf.
    */
   decode: function (bytes) {
     return TestArenaMap._readMessage(
@@ -48592,14 +48592,14 @@ export const TestArenaMap = {
   },
 
   /**
-   * Serializes a TestArenaMap to JSON.
+   * Serializes TestArenaMap to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestArenaMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestArenaMap from JSON.
+   * Deserializes TestArenaMap from JSON.
    */
   decodeJSON: function (json) {
     return TestArenaMap._readMessageJSON(
@@ -48609,7 +48609,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Initializes a TestArenaMap with all fields set to their default value.
+   * Initializes TestArenaMap with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -50511,7 +50511,7 @@ export const TestArenaMap = {
 
 export const MessageContainingMapCalledEntry = {
   /**
-   * Serializes a MessageContainingMapCalledEntry to protobuf.
+   * Serializes MessageContainingMapCalledEntry to protobuf.
    */
   encode: function (msg) {
     return MessageContainingMapCalledEntry._writeMessage(
@@ -50521,7 +50521,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from protobuf.
+   * Deserializes MessageContainingMapCalledEntry from protobuf.
    */
   decode: function (bytes) {
     return MessageContainingMapCalledEntry._readMessage(
@@ -50531,7 +50531,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Serializes a MessageContainingMapCalledEntry to JSON.
+   * Serializes MessageContainingMapCalledEntry to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(
@@ -50540,7 +50540,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from JSON.
+   * Deserializes MessageContainingMapCalledEntry from JSON.
    */
   decodeJSON: function (json) {
     return MessageContainingMapCalledEntry._readMessageJSON(
@@ -50550,7 +50550,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Initializes a MessageContainingMapCalledEntry with all fields set to their default value.
+   * Initializes MessageContainingMapCalledEntry with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -50706,7 +50706,7 @@ export const MessageContainingMapCalledEntry = {
 
 export const TestRecursiveMapMessage = {
   /**
-   * Serializes a TestRecursiveMapMessage to protobuf.
+   * Serializes TestRecursiveMapMessage to protobuf.
    */
   encode: function (msg) {
     return TestRecursiveMapMessage._writeMessage(
@@ -50716,7 +50716,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from protobuf.
+   * Deserializes TestRecursiveMapMessage from protobuf.
    */
   decode: function (bytes) {
     return TestRecursiveMapMessage._readMessage(
@@ -50726,14 +50726,14 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMapMessage to JSON.
+   * Serializes TestRecursiveMapMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestRecursiveMapMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from JSON.
+   * Deserializes TestRecursiveMapMessage from JSON.
    */
   decodeJSON: function (json) {
     return TestRecursiveMapMessage._readMessageJSON(
@@ -50743,7 +50743,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMapMessage with all fields set to their default value.
+   * Initializes TestRecursiveMapMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -50945,35 +50945,35 @@ import {
 
 export const Any = {
   /**
-   * Serializes a Any to protobuf.
+   * Serializes Any to protobuf.
    */
   encode: function (msg) {
     return Any._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Any from protobuf.
+   * Deserializes Any from protobuf.
    */
   decode: function (bytes) {
     return Any._readMessage(Any.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Any to JSON.
+   * Serializes Any to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Any._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Any from JSON.
+   * Deserializes Any from JSON.
    */
   decodeJSON: function (json) {
     return Any._readMessageJSON(Any.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Any with all fields set to their default value.
+   * Initializes Any with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -51083,7 +51083,7 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const SourceContext = {
   /**
-   * Serializes a SourceContext to protobuf.
+   * Serializes SourceContext to protobuf.
    */
   encode: function (msg) {
     return SourceContext._writeMessage(
@@ -51093,7 +51093,7 @@ export const SourceContext = {
   },
 
   /**
-   * Deserializes a SourceContext from protobuf.
+   * Deserializes SourceContext from protobuf.
    */
   decode: function (bytes) {
     return SourceContext._readMessage(
@@ -51103,14 +51103,14 @@ export const SourceContext = {
   },
 
   /**
-   * Serializes a SourceContext to JSON.
+   * Serializes SourceContext to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(SourceContext._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SourceContext from JSON.
+   * Deserializes SourceContext from JSON.
    */
   decodeJSON: function (json) {
     return SourceContext._readMessageJSON(
@@ -51120,7 +51120,7 @@ export const SourceContext = {
   },
 
   /**
-   * Initializes a SourceContext with all fields set to their default value.
+   * Initializes SourceContext with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -51263,35 +51263,35 @@ export const Syntax = {
 
 export const Type = {
   /**
-   * Serializes a Type to protobuf.
+   * Serializes Type to protobuf.
    */
   encode: function (msg) {
     return Type._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Type from protobuf.
+   * Deserializes Type from protobuf.
    */
   decode: function (bytes) {
     return Type._readMessage(Type.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Type to JSON.
+   * Serializes Type to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Type._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Type from JSON.
+   * Deserializes Type from JSON.
    */
   decodeJSON: function (json) {
     return Type._readMessageJSON(Type.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Type with all fields set to their default value.
+   * Initializes Type with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -51446,35 +51446,35 @@ export const Type = {
 
 export const Field = {
   /**
-   * Serializes a Field to protobuf.
+   * Serializes Field to protobuf.
    */
   encode: function (msg) {
     return Field._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Field from protobuf.
+   * Deserializes Field from protobuf.
    */
   decode: function (bytes) {
     return Field._readMessage(Field.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Field to JSON.
+   * Serializes Field to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Field._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Field from JSON.
+   * Deserializes Field from JSON.
    */
   decodeJSON: function (json) {
     return Field._readMessageJSON(Field.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Field with all fields set to their default value.
+   * Initializes Field with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -51958,35 +51958,35 @@ export const Field = {
 
 export const Enum = {
   /**
-   * Serializes a Enum to protobuf.
+   * Serializes Enum to protobuf.
    */
   encode: function (msg) {
     return Enum._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Enum from protobuf.
+   * Deserializes Enum from protobuf.
    */
   decode: function (bytes) {
     return Enum._readMessage(Enum.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Enum to JSON.
+   * Serializes Enum to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Enum._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Enum from JSON.
+   * Deserializes Enum from JSON.
    */
   decodeJSON: function (json) {
     return Enum._readMessageJSON(Enum.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Enum with all fields set to their default value.
+   * Initializes Enum with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52126,14 +52126,14 @@ export const Enum = {
 
 export const EnumValue = {
   /**
-   * Serializes a EnumValue to protobuf.
+   * Serializes EnumValue to protobuf.
    */
   encode: function (msg) {
     return EnumValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a EnumValue from protobuf.
+   * Deserializes EnumValue from protobuf.
    */
   decode: function (bytes) {
     return EnumValue._readMessage(
@@ -52143,21 +52143,21 @@ export const EnumValue = {
   },
 
   /**
-   * Serializes a EnumValue to JSON.
+   * Serializes EnumValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(EnumValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a EnumValue from JSON.
+   * Deserializes EnumValue from JSON.
    */
   decodeJSON: function (json) {
     return EnumValue._readMessageJSON(EnumValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a EnumValue with all fields set to their default value.
+   * Initializes EnumValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52256,35 +52256,35 @@ export const EnumValue = {
 
 export const Option = {
   /**
-   * Serializes a Option to protobuf.
+   * Serializes Option to protobuf.
    */
   encode: function (msg) {
     return Option._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Option from protobuf.
+   * Deserializes Option from protobuf.
    */
   decode: function (bytes) {
     return Option._readMessage(Option.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Option to JSON.
+   * Serializes Option to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Option._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Option from JSON.
+   * Deserializes Option from JSON.
    */
   decodeJSON: function (json) {
     return Option._readMessageJSON(Option.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Option with all fields set to their default value.
+   * Initializes Option with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52402,35 +52402,35 @@ import { SourceContext } from \\"./source_context.pb\\";
 
 export const Api = {
   /**
-   * Serializes a Api to protobuf.
+   * Serializes Api to protobuf.
    */
   encode: function (msg) {
     return Api._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Api from protobuf.
+   * Deserializes Api from protobuf.
    */
   decode: function (bytes) {
     return Api._readMessage(Api.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Api to JSON.
+   * Serializes Api to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Api._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Api from JSON.
+   * Deserializes Api from JSON.
    */
   decodeJSON: function (json) {
     return Api._readMessageJSON(Api.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Api with all fields set to their default value.
+   * Initializes Api with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52606,35 +52606,35 @@ export const Api = {
 
 export const Method = {
   /**
-   * Serializes a Method to protobuf.
+   * Serializes Method to protobuf.
    */
   encode: function (msg) {
     return Method._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Method from protobuf.
+   * Deserializes Method from protobuf.
    */
   decode: function (bytes) {
     return Method._readMessage(Method.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Method to JSON.
+   * Serializes Method to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Method._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Method from JSON.
+   * Deserializes Method from JSON.
    */
   decodeJSON: function (json) {
     return Method._readMessageJSON(Method.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Method with all fields set to their default value.
+   * Initializes Method with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52794,35 +52794,35 @@ export const Method = {
 
 export const Mixin = {
   /**
-   * Serializes a Mixin to protobuf.
+   * Serializes Mixin to protobuf.
    */
   encode: function (msg) {
     return Mixin._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Mixin from protobuf.
+   * Deserializes Mixin from protobuf.
    */
   decode: function (bytes) {
     return Mixin._readMessage(Mixin.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Mixin to JSON.
+   * Serializes Mixin to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Mixin._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Mixin from JSON.
+   * Deserializes Mixin from JSON.
    */
   decodeJSON: function (json) {
     return Mixin._readMessageJSON(Mixin.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Mixin with all fields set to their default value.
+   * Initializes Mixin with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -52932,14 +52932,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Duration = {
   /**
-   * Serializes a Duration to protobuf.
+   * Serializes Duration to protobuf.
    */
   encode: function (msg) {
     return Duration._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Duration from protobuf.
+   * Deserializes Duration from protobuf.
    */
   decode: function (bytes) {
     return Duration._readMessage(
@@ -52949,21 +52949,21 @@ export const Duration = {
   },
 
   /**
-   * Serializes a Duration to JSON.
+   * Serializes Duration to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Duration._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Duration from JSON.
+   * Deserializes Duration from JSON.
    */
   decodeJSON: function (json) {
     return Duration._readMessageJSON(Duration.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Duration with all fields set to their default value.
+   * Initializes Duration with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53073,35 +53073,35 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Empty = {
   /**
-   * Serializes a Empty to protobuf.
+   * Serializes Empty to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a Empty from protobuf.
+   * Deserializes Empty from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a Empty to JSON.
+   * Serializes Empty to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a Empty from JSON.
+   * Deserializes Empty from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a Empty with all fields set to their default value.
+   * Initializes Empty with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -53170,14 +53170,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const FieldMask = {
   /**
-   * Serializes a FieldMask to protobuf.
+   * Serializes FieldMask to protobuf.
    */
   encode: function (msg) {
     return FieldMask._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FieldMask from protobuf.
+   * Deserializes FieldMask from protobuf.
    */
   decode: function (bytes) {
     return FieldMask._readMessage(
@@ -53187,21 +53187,21 @@ export const FieldMask = {
   },
 
   /**
-   * Serializes a FieldMask to JSON.
+   * Serializes FieldMask to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(FieldMask._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FieldMask from JSON.
+   * Deserializes FieldMask from JSON.
    */
   decodeJSON: function (json) {
     return FieldMask._readMessageJSON(FieldMask.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a FieldMask with all fields set to their default value.
+   * Initializes FieldMask with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53331,35 +53331,35 @@ export const NullValue = {
 
 export const Struct = {
   /**
-   * Serializes a Struct to protobuf.
+   * Serializes Struct to protobuf.
    */
   encode: function (msg) {
     return Struct._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Struct from protobuf.
+   * Deserializes Struct from protobuf.
    */
   decode: function (bytes) {
     return Struct._readMessage(Struct.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Struct to JSON.
+   * Serializes Struct to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Struct._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Struct from JSON.
+   * Deserializes Struct from JSON.
    */
   decodeJSON: function (json) {
     return Struct._readMessageJSON(Struct.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Struct with all fields set to their default value.
+   * Initializes Struct with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53517,35 +53517,35 @@ export const Struct = {
 
 export const Value = {
   /**
-   * Serializes a Value to protobuf.
+   * Serializes Value to protobuf.
    */
   encode: function (msg) {
     return Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Value from protobuf.
+   * Deserializes Value from protobuf.
    */
   decode: function (bytes) {
     return Value._readMessage(Value.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Value to JSON.
+   * Serializes Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Value from JSON.
+   * Deserializes Value from JSON.
    */
   decodeJSON: function (json) {
     return Value._readMessageJSON(Value.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Value with all fields set to their default value.
+   * Initializes Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53689,14 +53689,14 @@ export const Value = {
 
 export const ListValue = {
   /**
-   * Serializes a ListValue to protobuf.
+   * Serializes ListValue to protobuf.
    */
   encode: function (msg) {
     return ListValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a ListValue from protobuf.
+   * Deserializes ListValue from protobuf.
    */
   decode: function (bytes) {
     return ListValue._readMessage(
@@ -53706,21 +53706,21 @@ export const ListValue = {
   },
 
   /**
-   * Serializes a ListValue to JSON.
+   * Serializes ListValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ListValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ListValue from JSON.
+   * Deserializes ListValue from JSON.
    */
   decodeJSON: function (json) {
     return ListValue._readMessageJSON(ListValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a ListValue with all fields set to their default value.
+   * Initializes ListValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53821,14 +53821,14 @@ import { BinaryReader, BinaryWriter } from \\"twirpscript\\";
 
 export const Timestamp = {
   /**
-   * Serializes a Timestamp to protobuf.
+   * Serializes Timestamp to protobuf.
    */
   encode: function (msg) {
     return Timestamp._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Timestamp from protobuf.
+   * Deserializes Timestamp from protobuf.
    */
   decode: function (bytes) {
     return Timestamp._readMessage(
@@ -53838,21 +53838,21 @@ export const Timestamp = {
   },
 
   /**
-   * Serializes a Timestamp to JSON.
+   * Serializes Timestamp to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Timestamp._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Timestamp from JSON.
+   * Deserializes Timestamp from JSON.
    */
   decodeJSON: function (json) {
     return Timestamp._readMessageJSON(Timestamp.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Timestamp with all fields set to their default value.
+   * Initializes Timestamp with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -53967,14 +53967,14 @@ import {
 
 export const DoubleValue = {
   /**
-   * Serializes a DoubleValue to protobuf.
+   * Serializes DoubleValue to protobuf.
    */
   encode: function (msg) {
     return DoubleValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a DoubleValue from protobuf.
+   * Deserializes DoubleValue from protobuf.
    */
   decode: function (bytes) {
     return DoubleValue._readMessage(
@@ -53984,14 +53984,14 @@ export const DoubleValue = {
   },
 
   /**
-   * Serializes a DoubleValue to JSON.
+   * Serializes DoubleValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(DoubleValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a DoubleValue from JSON.
+   * Deserializes DoubleValue from JSON.
    */
   decodeJSON: function (json) {
     return DoubleValue._readMessageJSON(
@@ -54001,7 +54001,7 @@ export const DoubleValue = {
   },
 
   /**
-   * Initializes a DoubleValue with all fields set to their default value.
+   * Initializes DoubleValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54064,14 +54064,14 @@ export const DoubleValue = {
 
 export const FloatValue = {
   /**
-   * Serializes a FloatValue to protobuf.
+   * Serializes FloatValue to protobuf.
    */
   encode: function (msg) {
     return FloatValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FloatValue from protobuf.
+   * Deserializes FloatValue from protobuf.
    */
   decode: function (bytes) {
     return FloatValue._readMessage(
@@ -54081,14 +54081,14 @@ export const FloatValue = {
   },
 
   /**
-   * Serializes a FloatValue to JSON.
+   * Serializes FloatValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(FloatValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FloatValue from JSON.
+   * Deserializes FloatValue from JSON.
    */
   decodeJSON: function (json) {
     return FloatValue._readMessageJSON(
@@ -54098,7 +54098,7 @@ export const FloatValue = {
   },
 
   /**
-   * Initializes a FloatValue with all fields set to their default value.
+   * Initializes FloatValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54161,14 +54161,14 @@ export const FloatValue = {
 
 export const Int64Value = {
   /**
-   * Serializes a Int64Value to protobuf.
+   * Serializes Int64Value to protobuf.
    */
   encode: function (msg) {
     return Int64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int64Value from protobuf.
+   * Deserializes Int64Value from protobuf.
    */
   decode: function (bytes) {
     return Int64Value._readMessage(
@@ -54178,14 +54178,14 @@ export const Int64Value = {
   },
 
   /**
-   * Serializes a Int64Value to JSON.
+   * Serializes Int64Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Value from JSON.
+   * Deserializes Int64Value from JSON.
    */
   decodeJSON: function (json) {
     return Int64Value._readMessageJSON(
@@ -54195,7 +54195,7 @@ export const Int64Value = {
   },
 
   /**
-   * Initializes a Int64Value with all fields set to their default value.
+   * Initializes Int64Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54258,14 +54258,14 @@ export const Int64Value = {
 
 export const UInt64Value = {
   /**
-   * Serializes a UInt64Value to protobuf.
+   * Serializes UInt64Value to protobuf.
    */
   encode: function (msg) {
     return UInt64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt64Value from protobuf.
+   * Deserializes UInt64Value from protobuf.
    */
   decode: function (bytes) {
     return UInt64Value._readMessage(
@@ -54275,14 +54275,14 @@ export const UInt64Value = {
   },
 
   /**
-   * Serializes a UInt64Value to JSON.
+   * Serializes UInt64Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(UInt64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt64Value from JSON.
+   * Deserializes UInt64Value from JSON.
    */
   decodeJSON: function (json) {
     return UInt64Value._readMessageJSON(
@@ -54292,7 +54292,7 @@ export const UInt64Value = {
   },
 
   /**
-   * Initializes a UInt64Value with all fields set to their default value.
+   * Initializes UInt64Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54355,14 +54355,14 @@ export const UInt64Value = {
 
 export const Int32Value = {
   /**
-   * Serializes a Int32Value to protobuf.
+   * Serializes Int32Value to protobuf.
    */
   encode: function (msg) {
     return Int32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int32Value from protobuf.
+   * Deserializes Int32Value from protobuf.
    */
   decode: function (bytes) {
     return Int32Value._readMessage(
@@ -54372,14 +54372,14 @@ export const Int32Value = {
   },
 
   /**
-   * Serializes a Int32Value to JSON.
+   * Serializes Int32Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(Int32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Value from JSON.
+   * Deserializes Int32Value from JSON.
    */
   decodeJSON: function (json) {
     return Int32Value._readMessageJSON(
@@ -54389,7 +54389,7 @@ export const Int32Value = {
   },
 
   /**
-   * Initializes a Int32Value with all fields set to their default value.
+   * Initializes Int32Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54452,14 +54452,14 @@ export const Int32Value = {
 
 export const UInt32Value = {
   /**
-   * Serializes a UInt32Value to protobuf.
+   * Serializes UInt32Value to protobuf.
    */
   encode: function (msg) {
     return UInt32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt32Value from protobuf.
+   * Deserializes UInt32Value from protobuf.
    */
   decode: function (bytes) {
     return UInt32Value._readMessage(
@@ -54469,14 +54469,14 @@ export const UInt32Value = {
   },
 
   /**
-   * Serializes a UInt32Value to JSON.
+   * Serializes UInt32Value to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(UInt32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt32Value from JSON.
+   * Deserializes UInt32Value from JSON.
    */
   decodeJSON: function (json) {
     return UInt32Value._readMessageJSON(
@@ -54486,7 +54486,7 @@ export const UInt32Value = {
   },
 
   /**
-   * Initializes a UInt32Value with all fields set to their default value.
+   * Initializes UInt32Value with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54549,14 +54549,14 @@ export const UInt32Value = {
 
 export const BoolValue = {
   /**
-   * Serializes a BoolValue to protobuf.
+   * Serializes BoolValue to protobuf.
    */
   encode: function (msg) {
     return BoolValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolValue from protobuf.
+   * Deserializes BoolValue from protobuf.
    */
   decode: function (bytes) {
     return BoolValue._readMessage(
@@ -54566,21 +54566,21 @@ export const BoolValue = {
   },
 
   /**
-   * Serializes a BoolValue to JSON.
+   * Serializes BoolValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BoolValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolValue from JSON.
+   * Deserializes BoolValue from JSON.
    */
   decodeJSON: function (json) {
     return BoolValue._readMessageJSON(BoolValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a BoolValue with all fields set to their default value.
+   * Initializes BoolValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54643,14 +54643,14 @@ export const BoolValue = {
 
 export const StringValue = {
   /**
-   * Serializes a StringValue to protobuf.
+   * Serializes StringValue to protobuf.
    */
   encode: function (msg) {
     return StringValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a StringValue from protobuf.
+   * Deserializes StringValue from protobuf.
    */
   decode: function (bytes) {
     return StringValue._readMessage(
@@ -54660,14 +54660,14 @@ export const StringValue = {
   },
 
   /**
-   * Serializes a StringValue to JSON.
+   * Serializes StringValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(StringValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a StringValue from JSON.
+   * Deserializes StringValue from JSON.
    */
   decodeJSON: function (json) {
     return StringValue._readMessageJSON(
@@ -54677,7 +54677,7 @@ export const StringValue = {
   },
 
   /**
-   * Initializes a StringValue with all fields set to their default value.
+   * Initializes StringValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54740,14 +54740,14 @@ export const StringValue = {
 
 export const BytesValue = {
   /**
-   * Serializes a BytesValue to protobuf.
+   * Serializes BytesValue to protobuf.
    */
   encode: function (msg) {
     return BytesValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BytesValue from protobuf.
+   * Deserializes BytesValue from protobuf.
    */
   decode: function (bytes) {
     return BytesValue._readMessage(
@@ -54757,14 +54757,14 @@ export const BytesValue = {
   },
 
   /**
-   * Serializes a BytesValue to JSON.
+   * Serializes BytesValue to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(BytesValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BytesValue from JSON.
+   * Deserializes BytesValue from JSON.
    */
   decodeJSON: function (json) {
     return BytesValue._readMessageJSON(
@@ -54774,7 +54774,7 @@ export const BytesValue = {
   },
 
   /**
-   * Initializes a BytesValue with all fields set to their default value.
+   * Initializes BytesValue with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -54890,7 +54890,7 @@ import {
 
 export const TestWellKnownTypes = {
   /**
-   * Serializes a TestWellKnownTypes to protobuf.
+   * Serializes TestWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return TestWellKnownTypes._writeMessage(
@@ -54900,7 +54900,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from protobuf.
+   * Deserializes TestWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return TestWellKnownTypes._readMessage(
@@ -54910,14 +54910,14 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Serializes a TestWellKnownTypes to JSON.
+   * Serializes TestWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from JSON.
+   * Deserializes TestWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestWellKnownTypes._readMessageJSON(
@@ -54927,7 +54927,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Initializes a TestWellKnownTypes with all fields set to their default value.
+   * Initializes TestWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -55365,7 +55365,7 @@ export const TestWellKnownTypes = {
 
 export const RepeatedWellKnownTypes = {
   /**
-   * Serializes a RepeatedWellKnownTypes to protobuf.
+   * Serializes RepeatedWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return RepeatedWellKnownTypes._writeMessage(
@@ -55375,7 +55375,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from protobuf.
+   * Deserializes RepeatedWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return RepeatedWellKnownTypes._readMessage(
@@ -55385,14 +55385,14 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Serializes a RepeatedWellKnownTypes to JSON.
+   * Serializes RepeatedWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(RepeatedWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from JSON.
+   * Deserializes RepeatedWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return RepeatedWellKnownTypes._readMessageJSON(
@@ -55402,7 +55402,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Initializes a RepeatedWellKnownTypes with all fields set to their default value.
+   * Initializes RepeatedWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -55859,7 +55859,7 @@ export const RepeatedWellKnownTypes = {
 
 export const OneofWellKnownTypes = {
   /**
-   * Serializes a OneofWellKnownTypes to protobuf.
+   * Serializes OneofWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return OneofWellKnownTypes._writeMessage(
@@ -55869,7 +55869,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from protobuf.
+   * Deserializes OneofWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return OneofWellKnownTypes._readMessage(
@@ -55879,14 +55879,14 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Serializes a OneofWellKnownTypes to JSON.
+   * Serializes OneofWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(OneofWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from JSON.
+   * Deserializes OneofWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return OneofWellKnownTypes._readMessageJSON(
@@ -55896,7 +55896,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Initializes a OneofWellKnownTypes with all fields set to their default value.
+   * Initializes OneofWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -56314,7 +56314,7 @@ export const OneofWellKnownTypes = {
 
 export const MapWellKnownTypes = {
   /**
-   * Serializes a MapWellKnownTypes to protobuf.
+   * Serializes MapWellKnownTypes to protobuf.
    */
   encode: function (msg) {
     return MapWellKnownTypes._writeMessage(
@@ -56324,7 +56324,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from protobuf.
+   * Deserializes MapWellKnownTypes from protobuf.
    */
   decode: function (bytes) {
     return MapWellKnownTypes._readMessage(
@@ -56334,14 +56334,14 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Serializes a MapWellKnownTypes to JSON.
+   * Serializes MapWellKnownTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(MapWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from JSON.
+   * Deserializes MapWellKnownTypes from JSON.
    */
   decodeJSON: function (json) {
     return MapWellKnownTypes._readMessageJSON(
@@ -56351,7 +56351,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Initializes a MapWellKnownTypes with all fields set to their default value.
+   * Initializes MapWellKnownTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -58549,7 +58549,7 @@ export const ForeignEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg) {
     return TestAllTypes._writeMessage(
@@ -58559,7 +58559,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return TestAllTypes._readMessage(
@@ -58569,14 +58569,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestAllTypes._readMessageJSON(
@@ -58586,7 +58586,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -59672,7 +59672,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg) {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -59682,7 +59682,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes) {
       return TestAllTypes.NestedMessage._readMessage(
@@ -59692,14 +59692,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg) {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json) {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -59709,7 +59709,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function () {
       return {
@@ -59773,7 +59773,7 @@ export const TestAllTypes = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestPackedTypes._writeMessage(
@@ -59783,7 +59783,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestPackedTypes._readMessage(
@@ -59793,14 +59793,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestPackedTypes._readMessageJSON(
@@ -59810,7 +59810,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -60083,7 +60083,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg) {
     return TestUnpackedTypes._writeMessage(
@@ -60093,7 +60093,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes) {
     return TestUnpackedTypes._readMessage(
@@ -60103,14 +60103,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json) {
     return TestUnpackedTypes._readMessageJSON(
@@ -60120,7 +60120,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -60399,7 +60399,7 @@ export const TestUnpackedTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg) {
     return NestedTestAllTypes._writeMessage(
@@ -60409,7 +60409,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes) {
     return NestedTestAllTypes._readMessage(
@@ -60419,14 +60419,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json) {
     return NestedTestAllTypes._readMessageJSON(
@@ -60436,7 +60436,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -60524,7 +60524,7 @@ export const NestedTestAllTypes = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg) {
     return ForeignMessage._writeMessage(
@@ -60534,7 +60534,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes) {
     return ForeignMessage._readMessage(
@@ -60544,14 +60544,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json) {
     return ForeignMessage._readMessageJSON(
@@ -60561,7 +60561,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -60624,35 +60624,35 @@ export const ForeignMessage = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg) {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes) {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg) {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json) {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -60689,7 +60689,7 @@ export const TestEmptyMessage = {
 
 export const TestMessageWithDummy = {
   /**
-   * Serializes a TestMessageWithDummy to protobuf.
+   * Serializes TestMessageWithDummy to protobuf.
    */
   encode: function (msg) {
     return TestMessageWithDummy._writeMessage(
@@ -60699,7 +60699,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from protobuf.
+   * Deserializes TestMessageWithDummy from protobuf.
    */
   decode: function (bytes) {
     return TestMessageWithDummy._readMessage(
@@ -60709,14 +60709,14 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Serializes a TestMessageWithDummy to JSON.
+   * Serializes TestMessageWithDummy to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestMessageWithDummy._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from JSON.
+   * Deserializes TestMessageWithDummy from JSON.
    */
   decodeJSON: function (json) {
     return TestMessageWithDummy._readMessageJSON(
@@ -60726,7 +60726,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Initializes a TestMessageWithDummy with all fields set to their default value.
+   * Initializes TestMessageWithDummy with all fields set to their default value.
    */
   initialize: function () {
     return {
@@ -60789,14 +60789,14 @@ export const TestMessageWithDummy = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg) {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes) {
     return TestOneof2._readMessage(
@@ -60806,14 +60806,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg) {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json) {
     return TestOneof2._readMessageJSON(
@@ -60823,7 +60823,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function () {
     return {};
@@ -61061,7 +61061,7 @@ export interface PublicImportMessage {
 
 export const PublicImportMessage = {
   /**
-   * Serializes a PublicImportMessage to protobuf.
+   * Serializes PublicImportMessage to protobuf.
    */
   encode: function (msg: Partial<PublicImportMessage>): Uint8Array {
     return PublicImportMessage._writeMessage(
@@ -61071,7 +61071,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Deserializes a PublicImportMessage from protobuf.
+   * Deserializes PublicImportMessage from protobuf.
    */
   decode: function (bytes: ByteSource): PublicImportMessage {
     return PublicImportMessage._readMessage(
@@ -61081,14 +61081,14 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Serializes a PublicImportMessage to JSON.
+   * Serializes PublicImportMessage to JSON.
    */
   encodeJSON: function (msg: Partial<PublicImportMessage>): string {
     return JSON.stringify(PublicImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a PublicImportMessage from JSON.
+   * Deserializes PublicImportMessage from JSON.
    */
   decodeJSON: function (json: string): PublicImportMessage {
     return PublicImportMessage._readMessageJSON(
@@ -61098,7 +61098,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Initializes a PublicImportMessage with all fields set to their default value.
+   * Initializes PublicImportMessage with all fields set to their default value.
    */
   initialize: function (): PublicImportMessage {
     return {
@@ -61305,7 +61305,7 @@ export const ImportEnumForMap = {
 
 export const ImportMessage = {
   /**
-   * Serializes a ImportMessage to protobuf.
+   * Serializes ImportMessage to protobuf.
    */
   encode: function (msg: Partial<ImportMessage>): Uint8Array {
     return ImportMessage._writeMessage(
@@ -61315,7 +61315,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Deserializes a ImportMessage from protobuf.
+   * Deserializes ImportMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ImportMessage {
     return ImportMessage._readMessage(
@@ -61325,14 +61325,14 @@ export const ImportMessage = {
   },
 
   /**
-   * Serializes a ImportMessage to JSON.
+   * Serializes ImportMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ImportMessage>): string {
     return JSON.stringify(ImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ImportMessage from JSON.
+   * Deserializes ImportMessage from JSON.
    */
   decodeJSON: function (json: string): ImportMessage {
     return ImportMessage._readMessageJSON(
@@ -61342,7 +61342,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Initializes a ImportMessage with all fields set to their default value.
+   * Initializes ImportMessage with all fields set to their default value.
    */
   initialize: function (): ImportMessage {
     return {
@@ -63395,7 +63395,7 @@ export const VeryLargeEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg: Partial<TestAllTypes>): Uint8Array {
     return TestAllTypes._writeMessage(
@@ -63405,7 +63405,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestAllTypes {
     return TestAllTypes._readMessage(
@@ -63415,14 +63415,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestAllTypes>): string {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json: string): TestAllTypes {
     return TestAllTypes._readMessageJSON(
@@ -63432,7 +63432,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function (): TestAllTypes {
     return {
@@ -64839,7 +64839,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.NestedMessage>): Uint8Array {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -64849,7 +64849,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessage(
@@ -64859,14 +64859,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.NestedMessage>): string {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -64876,7 +64876,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.NestedMessage {
       return {
@@ -64950,7 +64950,7 @@ export const TestAllTypes = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestAllTypes.OptionalGroup to protobuf.
+     * Serializes TestAllTypes.OptionalGroup to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.OptionalGroup>): Uint8Array {
       return TestAllTypes.OptionalGroup._writeMessage(
@@ -64960,7 +64960,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from protobuf.
+     * Deserializes TestAllTypes.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.OptionalGroup {
       return TestAllTypes.OptionalGroup._readMessage(
@@ -64970,14 +64970,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.OptionalGroup to JSON.
+     * Serializes TestAllTypes.OptionalGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.OptionalGroup>): string {
       return JSON.stringify(TestAllTypes.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from JSON.
+     * Deserializes TestAllTypes.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.OptionalGroup {
       return TestAllTypes.OptionalGroup._readMessageJSON(
@@ -64987,7 +64987,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.OptionalGroup with all fields set to their default value.
+     * Initializes TestAllTypes.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.OptionalGroup {
       return {
@@ -65061,7 +65061,7 @@ export const TestAllTypes = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to protobuf.
+     * Serializes TestAllTypes.RepeatedGroup to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.RepeatedGroup>): Uint8Array {
       return TestAllTypes.RepeatedGroup._writeMessage(
@@ -65071,7 +65071,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from protobuf.
+     * Deserializes TestAllTypes.RepeatedGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.RepeatedGroup {
       return TestAllTypes.RepeatedGroup._readMessage(
@@ -65081,14 +65081,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to JSON.
+     * Serializes TestAllTypes.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.RepeatedGroup>): string {
       return JSON.stringify(TestAllTypes.RepeatedGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from JSON.
+     * Deserializes TestAllTypes.RepeatedGroup from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.RepeatedGroup {
       return TestAllTypes.RepeatedGroup._readMessageJSON(
@@ -65098,7 +65098,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.RepeatedGroup with all fields set to their default value.
+     * Initializes TestAllTypes.RepeatedGroup with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.RepeatedGroup {
       return {
@@ -65173,7 +65173,7 @@ export const TestAllTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg: Partial<NestedTestAllTypes>): Uint8Array {
     return NestedTestAllTypes._writeMessage(
@@ -65183,7 +65183,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): NestedTestAllTypes {
     return NestedTestAllTypes._readMessage(
@@ -65193,14 +65193,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<NestedTestAllTypes>): string {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json: string): NestedTestAllTypes {
     return NestedTestAllTypes._readMessageJSON(
@@ -65210,7 +65210,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function (): NestedTestAllTypes {
     return {
@@ -65336,7 +65336,7 @@ export const NestedTestAllTypes = {
 
 export const TestDeprecatedFields = {
   /**
-   * Serializes a TestDeprecatedFields to protobuf.
+   * Serializes TestDeprecatedFields to protobuf.
    */
   encode: function (msg: Partial<TestDeprecatedFields>): Uint8Array {
     return TestDeprecatedFields._writeMessage(
@@ -65346,7 +65346,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from protobuf.
+   * Deserializes TestDeprecatedFields from protobuf.
    */
   decode: function (bytes: ByteSource): TestDeprecatedFields {
     return TestDeprecatedFields._readMessage(
@@ -65356,14 +65356,14 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Serializes a TestDeprecatedFields to JSON.
+   * Serializes TestDeprecatedFields to JSON.
    */
   encodeJSON: function (msg: Partial<TestDeprecatedFields>): string {
     return JSON.stringify(TestDeprecatedFields._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from JSON.
+   * Deserializes TestDeprecatedFields from JSON.
    */
   decodeJSON: function (json: string): TestDeprecatedFields {
     return TestDeprecatedFields._readMessageJSON(
@@ -65373,7 +65373,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Initializes a TestDeprecatedFields with all fields set to their default value.
+   * Initializes TestDeprecatedFields with all fields set to their default value.
    */
   initialize: function (): TestDeprecatedFields {
     return {
@@ -65462,35 +65462,35 @@ export const TestDeprecatedFields = {
 
 export const TestDeprecatedMessage = {
   /**
-   * Serializes a TestDeprecatedMessage to protobuf.
+   * Serializes TestDeprecatedMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestDeprecatedMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from protobuf.
+   * Deserializes TestDeprecatedMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestDeprecatedMessage {
     return {};
   },
 
   /**
-   * Serializes a TestDeprecatedMessage to JSON.
+   * Serializes TestDeprecatedMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestDeprecatedMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from JSON.
+   * Deserializes TestDeprecatedMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestDeprecatedMessage {
     return {};
   },
 
   /**
-   * Initializes a TestDeprecatedMessage with all fields set to their default value.
+   * Initializes TestDeprecatedMessage with all fields set to their default value.
    */
   initialize: function (): TestDeprecatedMessage {
     return {};
@@ -65538,7 +65538,7 @@ export const TestDeprecatedMessage = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg: Partial<ForeignMessage>): Uint8Array {
     return ForeignMessage._writeMessage(
@@ -65548,7 +65548,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ForeignMessage {
     return ForeignMessage._readMessage(
@@ -65558,14 +65558,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ForeignMessage>): string {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json: string): ForeignMessage {
     return ForeignMessage._readMessageJSON(
@@ -65575,7 +65575,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function (): ForeignMessage {
     return {
@@ -65661,35 +65661,35 @@ export const ForeignMessage = {
 
 export const TestReservedFields = {
   /**
-   * Serializes a TestReservedFields to protobuf.
+   * Serializes TestReservedFields to protobuf.
    */
   encode: function (_msg?: Partial<TestReservedFields>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestReservedFields from protobuf.
+   * Deserializes TestReservedFields from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestReservedFields {
     return {};
   },
 
   /**
-   * Serializes a TestReservedFields to JSON.
+   * Serializes TestReservedFields to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestReservedFields>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestReservedFields from JSON.
+   * Deserializes TestReservedFields from JSON.
    */
   decodeJSON: function (_json?: string): TestReservedFields {
     return {};
   },
 
   /**
-   * Initializes a TestReservedFields with all fields set to their default value.
+   * Initializes TestReservedFields with all fields set to their default value.
    */
   initialize: function (): TestReservedFields {
     return {};
@@ -65737,35 +65737,35 @@ export const TestReservedFields = {
 
 export const TestAllExtensions = {
   /**
-   * Serializes a TestAllExtensions to protobuf.
+   * Serializes TestAllExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestAllExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestAllExtensions from protobuf.
+   * Deserializes TestAllExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestAllExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestAllExtensions to JSON.
+   * Serializes TestAllExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestAllExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestAllExtensions from JSON.
+   * Deserializes TestAllExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestAllExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestAllExtensions with all fields set to their default value.
+   * Initializes TestAllExtensions with all fields set to their default value.
    */
   initialize: function (): TestAllExtensions {
     return {};
@@ -65813,7 +65813,7 @@ export const TestAllExtensions = {
 
 export const OptionalGroup_extension = {
   /**
-   * Serializes a OptionalGroup_extension to protobuf.
+   * Serializes OptionalGroup_extension to protobuf.
    */
   encode: function (msg: Partial<OptionalGroup_extension>): Uint8Array {
     return OptionalGroup_extension._writeMessage(
@@ -65823,7 +65823,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from protobuf.
+   * Deserializes OptionalGroup_extension from protobuf.
    */
   decode: function (bytes: ByteSource): OptionalGroup_extension {
     return OptionalGroup_extension._readMessage(
@@ -65833,14 +65833,14 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Serializes a OptionalGroup_extension to JSON.
+   * Serializes OptionalGroup_extension to JSON.
    */
   encodeJSON: function (msg: Partial<OptionalGroup_extension>): string {
     return JSON.stringify(OptionalGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from JSON.
+   * Deserializes OptionalGroup_extension from JSON.
    */
   decodeJSON: function (json: string): OptionalGroup_extension {
     return OptionalGroup_extension._readMessageJSON(
@@ -65850,7 +65850,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Initializes a OptionalGroup_extension with all fields set to their default value.
+   * Initializes OptionalGroup_extension with all fields set to their default value.
    */
   initialize: function (): OptionalGroup_extension {
     return {
@@ -65924,7 +65924,7 @@ export const OptionalGroup_extension = {
 
 export const RepeatedGroup_extension = {
   /**
-   * Serializes a RepeatedGroup_extension to protobuf.
+   * Serializes RepeatedGroup_extension to protobuf.
    */
   encode: function (msg: Partial<RepeatedGroup_extension>): Uint8Array {
     return RepeatedGroup_extension._writeMessage(
@@ -65934,7 +65934,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from protobuf.
+   * Deserializes RepeatedGroup_extension from protobuf.
    */
   decode: function (bytes: ByteSource): RepeatedGroup_extension {
     return RepeatedGroup_extension._readMessage(
@@ -65944,14 +65944,14 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Serializes a RepeatedGroup_extension to JSON.
+   * Serializes RepeatedGroup_extension to JSON.
    */
   encodeJSON: function (msg: Partial<RepeatedGroup_extension>): string {
     return JSON.stringify(RepeatedGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from JSON.
+   * Deserializes RepeatedGroup_extension from JSON.
    */
   decodeJSON: function (json: string): RepeatedGroup_extension {
     return RepeatedGroup_extension._readMessageJSON(
@@ -65961,7 +65961,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Initializes a RepeatedGroup_extension with all fields set to their default value.
+   * Initializes RepeatedGroup_extension with all fields set to their default value.
    */
   initialize: function (): RepeatedGroup_extension {
     return {
@@ -66035,14 +66035,14 @@ export const RepeatedGroup_extension = {
 
 export const TestGroup = {
   /**
-   * Serializes a TestGroup to protobuf.
+   * Serializes TestGroup to protobuf.
    */
   encode: function (msg: Partial<TestGroup>): Uint8Array {
     return TestGroup._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestGroup from protobuf.
+   * Deserializes TestGroup from protobuf.
    */
   decode: function (bytes: ByteSource): TestGroup {
     return TestGroup._readMessage(
@@ -66052,21 +66052,21 @@ export const TestGroup = {
   },
 
   /**
-   * Serializes a TestGroup to JSON.
+   * Serializes TestGroup to JSON.
    */
   encodeJSON: function (msg: Partial<TestGroup>): string {
     return JSON.stringify(TestGroup._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestGroup from JSON.
+   * Deserializes TestGroup from JSON.
    */
   decodeJSON: function (json: string): TestGroup {
     return TestGroup._readMessageJSON(TestGroup.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestGroup with all fields set to their default value.
+   * Initializes TestGroup with all fields set to their default value.
    */
   initialize: function (): TestGroup {
     return {
@@ -66140,7 +66140,7 @@ export const TestGroup = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestGroup.OptionalGroup to protobuf.
+     * Serializes TestGroup.OptionalGroup to protobuf.
      */
     encode: function (msg: Partial<TestGroup.OptionalGroup>): Uint8Array {
       return TestGroup.OptionalGroup._writeMessage(
@@ -66150,7 +66150,7 @@ export const TestGroup = {
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from protobuf.
+     * Deserializes TestGroup.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestGroup.OptionalGroup {
       return TestGroup.OptionalGroup._readMessage(
@@ -66160,14 +66160,14 @@ export const TestGroup = {
     },
 
     /**
-     * Serializes a TestGroup.OptionalGroup to JSON.
+     * Serializes TestGroup.OptionalGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestGroup.OptionalGroup>): string {
       return JSON.stringify(TestGroup.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from JSON.
+     * Deserializes TestGroup.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestGroup.OptionalGroup {
       return TestGroup.OptionalGroup._readMessageJSON(
@@ -66177,7 +66177,7 @@ export const TestGroup = {
     },
 
     /**
-     * Initializes a TestGroup.OptionalGroup with all fields set to their default value.
+     * Initializes TestGroup.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestGroup.OptionalGroup {
       return {
@@ -66252,35 +66252,35 @@ export const TestGroup = {
 
 export const TestGroupExtension = {
   /**
-   * Serializes a TestGroupExtension to protobuf.
+   * Serializes TestGroupExtension to protobuf.
    */
   encode: function (_msg?: Partial<TestGroupExtension>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestGroupExtension from protobuf.
+   * Deserializes TestGroupExtension from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestGroupExtension {
     return {};
   },
 
   /**
-   * Serializes a TestGroupExtension to JSON.
+   * Serializes TestGroupExtension to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestGroupExtension>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestGroupExtension from JSON.
+   * Deserializes TestGroupExtension from JSON.
    */
   decodeJSON: function (_json?: string): TestGroupExtension {
     return {};
   },
 
   /**
-   * Initializes a TestGroupExtension with all fields set to their default value.
+   * Initializes TestGroupExtension with all fields set to their default value.
    */
   initialize: function (): TestGroupExtension {
     return {};
@@ -66328,35 +66328,35 @@ export const TestGroupExtension = {
 
 export const TestNestedExtension = {
   /**
-   * Serializes a TestNestedExtension to protobuf.
+   * Serializes TestNestedExtension to protobuf.
    */
   encode: function (_msg?: Partial<TestNestedExtension>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestNestedExtension from protobuf.
+   * Deserializes TestNestedExtension from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestNestedExtension {
     return {};
   },
 
   /**
-   * Serializes a TestNestedExtension to JSON.
+   * Serializes TestNestedExtension to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestNestedExtension>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestNestedExtension from JSON.
+   * Deserializes TestNestedExtension from JSON.
    */
   decodeJSON: function (_json?: string): TestNestedExtension {
     return {};
   },
 
   /**
-   * Initializes a TestNestedExtension with all fields set to their default value.
+   * Initializes TestNestedExtension with all fields set to their default value.
    */
   initialize: function (): TestNestedExtension {
     return {};
@@ -66403,7 +66403,7 @@ export const TestNestedExtension = {
 
   OptionalGroup_extension: {
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to protobuf.
+     * Serializes TestNestedExtension.OptionalGroup_extension to protobuf.
      */
     encode: function (
       msg: Partial<TestNestedExtension.OptionalGroup_extension>
@@ -66415,7 +66415,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from protobuf.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -66427,7 +66427,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to JSON.
+     * Serializes TestNestedExtension.OptionalGroup_extension to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestNestedExtension.OptionalGroup_extension>
@@ -66438,7 +66438,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from JSON.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from JSON.
      */
     decodeJSON: function (
       json: string
@@ -66450,7 +66450,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Initializes a TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
+     * Initializes TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
      */
     initialize: function (): TestNestedExtension.OptionalGroup_extension {
       return {
@@ -66525,7 +66525,7 @@ export const TestNestedExtension = {
 
 export const TestChildExtension = {
   /**
-   * Serializes a TestChildExtension to protobuf.
+   * Serializes TestChildExtension to protobuf.
    */
   encode: function (msg: Partial<TestChildExtension>): Uint8Array {
     return TestChildExtension._writeMessage(
@@ -66535,7 +66535,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Deserializes a TestChildExtension from protobuf.
+   * Deserializes TestChildExtension from protobuf.
    */
   decode: function (bytes: ByteSource): TestChildExtension {
     return TestChildExtension._readMessage(
@@ -66545,14 +66545,14 @@ export const TestChildExtension = {
   },
 
   /**
-   * Serializes a TestChildExtension to JSON.
+   * Serializes TestChildExtension to JSON.
    */
   encodeJSON: function (msg: Partial<TestChildExtension>): string {
     return JSON.stringify(TestChildExtension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestChildExtension from JSON.
+   * Deserializes TestChildExtension from JSON.
    */
   decodeJSON: function (json: string): TestChildExtension {
     return TestChildExtension._readMessageJSON(
@@ -66562,7 +66562,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Initializes a TestChildExtension with all fields set to their default value.
+   * Initializes TestChildExtension with all fields set to their default value.
    */
   initialize: function (): TestChildExtension {
     return {
@@ -66681,7 +66681,7 @@ export const TestChildExtension = {
 
 export const TestRequired = {
   /**
-   * Serializes a TestRequired to protobuf.
+   * Serializes TestRequired to protobuf.
    */
   encode: function (msg: Partial<TestRequired>): Uint8Array {
     return TestRequired._writeMessage(
@@ -66691,7 +66691,7 @@ export const TestRequired = {
   },
 
   /**
-   * Deserializes a TestRequired from protobuf.
+   * Deserializes TestRequired from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequired {
     return TestRequired._readMessage(
@@ -66701,14 +66701,14 @@ export const TestRequired = {
   },
 
   /**
-   * Serializes a TestRequired to JSON.
+   * Serializes TestRequired to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequired>): string {
     return JSON.stringify(TestRequired._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequired from JSON.
+   * Deserializes TestRequired from JSON.
    */
   decodeJSON: function (json: string): TestRequired {
     return TestRequired._readMessageJSON(
@@ -66718,7 +66718,7 @@ export const TestRequired = {
   },
 
   /**
-   * Initializes a TestRequired with all fields set to their default value.
+   * Initializes TestRequired with all fields set to their default value.
    */
   initialize: function (): TestRequired {
     return {
@@ -67269,7 +67269,7 @@ export const TestRequired = {
 
 export const TestRequiredForeign = {
   /**
-   * Serializes a TestRequiredForeign to protobuf.
+   * Serializes TestRequiredForeign to protobuf.
    */
   encode: function (msg: Partial<TestRequiredForeign>): Uint8Array {
     return TestRequiredForeign._writeMessage(
@@ -67279,7 +67279,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Deserializes a TestRequiredForeign from protobuf.
+   * Deserializes TestRequiredForeign from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredForeign {
     return TestRequiredForeign._readMessage(
@@ -67289,14 +67289,14 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Serializes a TestRequiredForeign to JSON.
+   * Serializes TestRequiredForeign to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredForeign>): string {
     return JSON.stringify(TestRequiredForeign._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredForeign from JSON.
+   * Deserializes TestRequiredForeign from JSON.
    */
   decodeJSON: function (json: string): TestRequiredForeign {
     return TestRequiredForeign._readMessageJSON(
@@ -67306,7 +67306,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Initializes a TestRequiredForeign with all fields set to their default value.
+   * Initializes TestRequiredForeign with all fields set to their default value.
    */
   initialize: function (): TestRequiredForeign {
     return {
@@ -67429,7 +67429,7 @@ export const TestRequiredForeign = {
 
 export const TestRequiredMessage = {
   /**
-   * Serializes a TestRequiredMessage to protobuf.
+   * Serializes TestRequiredMessage to protobuf.
    */
   encode: function (msg: Partial<TestRequiredMessage>): Uint8Array {
     return TestRequiredMessage._writeMessage(
@@ -67439,7 +67439,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Deserializes a TestRequiredMessage from protobuf.
+   * Deserializes TestRequiredMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredMessage {
     return TestRequiredMessage._readMessage(
@@ -67449,14 +67449,14 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Serializes a TestRequiredMessage to JSON.
+   * Serializes TestRequiredMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredMessage>): string {
     return JSON.stringify(TestRequiredMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessage from JSON.
+   * Deserializes TestRequiredMessage from JSON.
    */
   decodeJSON: function (json: string): TestRequiredMessage {
     return TestRequiredMessage._readMessageJSON(
@@ -67466,7 +67466,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Initializes a TestRequiredMessage with all fields set to their default value.
+   * Initializes TestRequiredMessage with all fields set to their default value.
    */
   initialize: function (): TestRequiredMessage {
     return {
@@ -67596,7 +67596,7 @@ export const TestRequiredMessage = {
 
 export const TestForeignNested = {
   /**
-   * Serializes a TestForeignNested to protobuf.
+   * Serializes TestForeignNested to protobuf.
    */
   encode: function (msg: Partial<TestForeignNested>): Uint8Array {
     return TestForeignNested._writeMessage(
@@ -67606,7 +67606,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Deserializes a TestForeignNested from protobuf.
+   * Deserializes TestForeignNested from protobuf.
    */
   decode: function (bytes: ByteSource): TestForeignNested {
     return TestForeignNested._readMessage(
@@ -67616,14 +67616,14 @@ export const TestForeignNested = {
   },
 
   /**
-   * Serializes a TestForeignNested to JSON.
+   * Serializes TestForeignNested to JSON.
    */
   encodeJSON: function (msg: Partial<TestForeignNested>): string {
     return JSON.stringify(TestForeignNested._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestForeignNested from JSON.
+   * Deserializes TestForeignNested from JSON.
    */
   decodeJSON: function (json: string): TestForeignNested {
     return TestForeignNested._readMessageJSON(
@@ -67633,7 +67633,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Initializes a TestForeignNested with all fields set to their default value.
+   * Initializes TestForeignNested with all fields set to their default value.
    */
   initialize: function (): TestForeignNested {
     return {
@@ -67721,35 +67721,35 @@ export const TestForeignNested = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestEmptyMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestEmptyMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessage {
     return {};
@@ -67797,7 +67797,7 @@ export const TestEmptyMessage = {
 
 export const TestEmptyMessageWithExtensions = {
   /**
-   * Serializes a TestEmptyMessageWithExtensions to protobuf.
+   * Serializes TestEmptyMessageWithExtensions to protobuf.
    */
   encode: function (
     _msg?: Partial<TestEmptyMessageWithExtensions>
@@ -67806,14 +67806,14 @@ export const TestEmptyMessageWithExtensions = {
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from protobuf.
+   * Deserializes TestEmptyMessageWithExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessageWithExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessageWithExtensions to JSON.
+   * Serializes TestEmptyMessageWithExtensions to JSON.
    */
   encodeJSON: function (
     _msg?: Partial<TestEmptyMessageWithExtensions>
@@ -67822,14 +67822,14 @@ export const TestEmptyMessageWithExtensions = {
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from JSON.
+   * Deserializes TestEmptyMessageWithExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessageWithExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessageWithExtensions with all fields set to their default value.
+   * Initializes TestEmptyMessageWithExtensions with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessageWithExtensions {
     return {};
@@ -67877,35 +67877,35 @@ export const TestEmptyMessageWithExtensions = {
 
 export const TestPickleNestedMessage = {
   /**
-   * Serializes a TestPickleNestedMessage to protobuf.
+   * Serializes TestPickleNestedMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestPickleNestedMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from protobuf.
+   * Deserializes TestPickleNestedMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestPickleNestedMessage {
     return {};
   },
 
   /**
-   * Serializes a TestPickleNestedMessage to JSON.
+   * Serializes TestPickleNestedMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestPickleNestedMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from JSON.
+   * Deserializes TestPickleNestedMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestPickleNestedMessage {
     return {};
   },
 
   /**
-   * Initializes a TestPickleNestedMessage with all fields set to their default value.
+   * Initializes TestPickleNestedMessage with all fields set to their default value.
    */
   initialize: function (): TestPickleNestedMessage {
     return {};
@@ -67952,7 +67952,7 @@ export const TestPickleNestedMessage = {
 
   NestedMessage: {
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to protobuf.
+     * Serializes TestPickleNestedMessage.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestPickleNestedMessage.NestedMessage>
@@ -67964,7 +67964,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from protobuf.
+     * Deserializes TestPickleNestedMessage.NestedMessage from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -67976,7 +67976,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to JSON.
+     * Serializes TestPickleNestedMessage.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestPickleNestedMessage.NestedMessage>
@@ -67987,7 +67987,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from JSON.
+     * Deserializes TestPickleNestedMessage.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestPickleNestedMessage.NestedMessage {
       return TestPickleNestedMessage.NestedMessage._readMessageJSON(
@@ -67997,7 +67997,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Initializes a TestPickleNestedMessage.NestedMessage with all fields set to their default value.
+     * Initializes TestPickleNestedMessage.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestPickleNestedMessage.NestedMessage {
       return {
@@ -68070,7 +68070,7 @@ export const TestPickleNestedMessage = {
 
     NestedNestedMessage: {
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
        */
       encode: function (
         msg: Partial<TestPickleNestedMessage.NestedMessage.NestedNestedMessage>
@@ -68082,7 +68082,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -68094,7 +68094,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestPickleNestedMessage.NestedMessage.NestedNestedMessage>
@@ -68107,7 +68107,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
        */
       decodeJSON: function (
         json: string
@@ -68119,7 +68119,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Initializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
+       * Initializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
        */
       initialize:
         function (): TestPickleNestedMessage.NestedMessage.NestedNestedMessage {
@@ -68196,35 +68196,35 @@ export const TestPickleNestedMessage = {
 
 export const TestMultipleExtensionRanges = {
   /**
-   * Serializes a TestMultipleExtensionRanges to protobuf.
+   * Serializes TestMultipleExtensionRanges to protobuf.
    */
   encode: function (_msg?: Partial<TestMultipleExtensionRanges>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from protobuf.
+   * Deserializes TestMultipleExtensionRanges from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestMultipleExtensionRanges {
     return {};
   },
 
   /**
-   * Serializes a TestMultipleExtensionRanges to JSON.
+   * Serializes TestMultipleExtensionRanges to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestMultipleExtensionRanges>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from JSON.
+   * Deserializes TestMultipleExtensionRanges from JSON.
    */
   decodeJSON: function (_json?: string): TestMultipleExtensionRanges {
     return {};
   },
 
   /**
-   * Initializes a TestMultipleExtensionRanges with all fields set to their default value.
+   * Initializes TestMultipleExtensionRanges with all fields set to their default value.
    */
   initialize: function (): TestMultipleExtensionRanges {
     return {};
@@ -68272,7 +68272,7 @@ export const TestMultipleExtensionRanges = {
 
 export const TestReallyLargeTagNumber = {
   /**
-   * Serializes a TestReallyLargeTagNumber to protobuf.
+   * Serializes TestReallyLargeTagNumber to protobuf.
    */
   encode: function (msg: Partial<TestReallyLargeTagNumber>): Uint8Array {
     return TestReallyLargeTagNumber._writeMessage(
@@ -68282,7 +68282,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from protobuf.
+   * Deserializes TestReallyLargeTagNumber from protobuf.
    */
   decode: function (bytes: ByteSource): TestReallyLargeTagNumber {
     return TestReallyLargeTagNumber._readMessage(
@@ -68292,14 +68292,14 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Serializes a TestReallyLargeTagNumber to JSON.
+   * Serializes TestReallyLargeTagNumber to JSON.
    */
   encodeJSON: function (msg: Partial<TestReallyLargeTagNumber>): string {
     return JSON.stringify(TestReallyLargeTagNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from JSON.
+   * Deserializes TestReallyLargeTagNumber from JSON.
    */
   decodeJSON: function (json: string): TestReallyLargeTagNumber {
     return TestReallyLargeTagNumber._readMessageJSON(
@@ -68309,7 +68309,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Initializes a TestReallyLargeTagNumber with all fields set to their default value.
+   * Initializes TestReallyLargeTagNumber with all fields set to their default value.
    */
   initialize: function (): TestReallyLargeTagNumber {
     return {
@@ -68398,7 +68398,7 @@ export const TestReallyLargeTagNumber = {
 
 export const TestRecursiveMessage = {
   /**
-   * Serializes a TestRecursiveMessage to protobuf.
+   * Serializes TestRecursiveMessage to protobuf.
    */
   encode: function (msg: Partial<TestRecursiveMessage>): Uint8Array {
     return TestRecursiveMessage._writeMessage(
@@ -68408,7 +68408,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from protobuf.
+   * Deserializes TestRecursiveMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRecursiveMessage {
     return TestRecursiveMessage._readMessage(
@@ -68418,14 +68418,14 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMessage to JSON.
+   * Serializes TestRecursiveMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRecursiveMessage>): string {
     return JSON.stringify(TestRecursiveMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from JSON.
+   * Deserializes TestRecursiveMessage from JSON.
    */
   decodeJSON: function (json: string): TestRecursiveMessage {
     return TestRecursiveMessage._readMessageJSON(
@@ -68435,7 +68435,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMessage with all fields set to their default value.
+   * Initializes TestRecursiveMessage with all fields set to their default value.
    */
   initialize: function (): TestRecursiveMessage {
     return {
@@ -68529,7 +68529,7 @@ export const TestRecursiveMessage = {
 
 export const TestMutualRecursionA = {
   /**
-   * Serializes a TestMutualRecursionA to protobuf.
+   * Serializes TestMutualRecursionA to protobuf.
    */
   encode: function (msg: Partial<TestMutualRecursionA>): Uint8Array {
     return TestMutualRecursionA._writeMessage(
@@ -68539,7 +68539,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from protobuf.
+   * Deserializes TestMutualRecursionA from protobuf.
    */
   decode: function (bytes: ByteSource): TestMutualRecursionA {
     return TestMutualRecursionA._readMessage(
@@ -68549,14 +68549,14 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Serializes a TestMutualRecursionA to JSON.
+   * Serializes TestMutualRecursionA to JSON.
    */
   encodeJSON: function (msg: Partial<TestMutualRecursionA>): string {
     return JSON.stringify(TestMutualRecursionA._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from JSON.
+   * Deserializes TestMutualRecursionA from JSON.
    */
   decodeJSON: function (json: string): TestMutualRecursionA {
     return TestMutualRecursionA._readMessageJSON(
@@ -68566,7 +68566,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Initializes a TestMutualRecursionA with all fields set to their default value.
+   * Initializes TestMutualRecursionA with all fields set to their default value.
    */
   initialize: function (): TestMutualRecursionA {
     return {
@@ -68644,7 +68644,7 @@ export const TestMutualRecursionA = {
 
   SubMessage: {
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to protobuf.
+     * Serializes TestMutualRecursionA.SubMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestMutualRecursionA.SubMessage>
@@ -68656,7 +68656,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from protobuf.
+     * Deserializes TestMutualRecursionA.SubMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestMutualRecursionA.SubMessage {
       return TestMutualRecursionA.SubMessage._readMessage(
@@ -68666,7 +68666,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to JSON.
+     * Serializes TestMutualRecursionA.SubMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestMutualRecursionA.SubMessage>
@@ -68677,7 +68677,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from JSON.
+     * Deserializes TestMutualRecursionA.SubMessage from JSON.
      */
     decodeJSON: function (json: string): TestMutualRecursionA.SubMessage {
       return TestMutualRecursionA.SubMessage._readMessageJSON(
@@ -68687,7 +68687,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubMessage with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubMessage with all fields set to their default value.
      */
     initialize: function (): TestMutualRecursionA.SubMessage {
       return {
@@ -68766,7 +68766,7 @@ export const TestMutualRecursionA = {
 
   SubGroup: {
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to protobuf.
+     * Serializes TestMutualRecursionA.SubGroup to protobuf.
      */
     encode: function (msg: Partial<TestMutualRecursionA.SubGroup>): Uint8Array {
       return TestMutualRecursionA.SubGroup._writeMessage(
@@ -68776,7 +68776,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from protobuf.
+     * Deserializes TestMutualRecursionA.SubGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestMutualRecursionA.SubGroup {
       return TestMutualRecursionA.SubGroup._readMessage(
@@ -68786,7 +68786,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to JSON.
+     * Serializes TestMutualRecursionA.SubGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestMutualRecursionA.SubGroup>): string {
       return JSON.stringify(
@@ -68795,7 +68795,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from JSON.
+     * Deserializes TestMutualRecursionA.SubGroup from JSON.
      */
     decodeJSON: function (json: string): TestMutualRecursionA.SubGroup {
       return TestMutualRecursionA.SubGroup._readMessageJSON(
@@ -68805,7 +68805,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubGroup with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubGroup with all fields set to their default value.
      */
     initialize: function (): TestMutualRecursionA.SubGroup {
       return {
@@ -68914,7 +68914,7 @@ export const TestMutualRecursionA = {
 
 export const TestMutualRecursionB = {
   /**
-   * Serializes a TestMutualRecursionB to protobuf.
+   * Serializes TestMutualRecursionB to protobuf.
    */
   encode: function (msg: Partial<TestMutualRecursionB>): Uint8Array {
     return TestMutualRecursionB._writeMessage(
@@ -68924,7 +68924,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from protobuf.
+   * Deserializes TestMutualRecursionB from protobuf.
    */
   decode: function (bytes: ByteSource): TestMutualRecursionB {
     return TestMutualRecursionB._readMessage(
@@ -68934,14 +68934,14 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Serializes a TestMutualRecursionB to JSON.
+   * Serializes TestMutualRecursionB to JSON.
    */
   encodeJSON: function (msg: Partial<TestMutualRecursionB>): string {
     return JSON.stringify(TestMutualRecursionB._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from JSON.
+   * Deserializes TestMutualRecursionB from JSON.
    */
   decodeJSON: function (json: string): TestMutualRecursionB {
     return TestMutualRecursionB._readMessageJSON(
@@ -68951,7 +68951,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Initializes a TestMutualRecursionB with all fields set to their default value.
+   * Initializes TestMutualRecursionB with all fields set to their default value.
    */
   initialize: function (): TestMutualRecursionB {
     return {
@@ -69045,7 +69045,7 @@ export const TestMutualRecursionB = {
 
 export const TestIsInitialized = {
   /**
-   * Serializes a TestIsInitialized to protobuf.
+   * Serializes TestIsInitialized to protobuf.
    */
   encode: function (msg: Partial<TestIsInitialized>): Uint8Array {
     return TestIsInitialized._writeMessage(
@@ -69055,7 +69055,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Deserializes a TestIsInitialized from protobuf.
+   * Deserializes TestIsInitialized from protobuf.
    */
   decode: function (bytes: ByteSource): TestIsInitialized {
     return TestIsInitialized._readMessage(
@@ -69065,14 +69065,14 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Serializes a TestIsInitialized to JSON.
+   * Serializes TestIsInitialized to JSON.
    */
   encodeJSON: function (msg: Partial<TestIsInitialized>): string {
     return JSON.stringify(TestIsInitialized._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestIsInitialized from JSON.
+   * Deserializes TestIsInitialized from JSON.
    */
   decodeJSON: function (json: string): TestIsInitialized {
     return TestIsInitialized._readMessageJSON(
@@ -69082,7 +69082,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Initializes a TestIsInitialized with all fields set to their default value.
+   * Initializes TestIsInitialized with all fields set to their default value.
    */
   initialize: function (): TestIsInitialized {
     return {
@@ -69169,7 +69169,7 @@ export const TestIsInitialized = {
 
   SubMessage: {
     /**
-     * Serializes a TestIsInitialized.SubMessage to protobuf.
+     * Serializes TestIsInitialized.SubMessage to protobuf.
      */
     encode: function (
       _msg?: Partial<TestIsInitialized.SubMessage>
@@ -69178,14 +69178,14 @@ export const TestIsInitialized = {
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from protobuf.
+     * Deserializes TestIsInitialized.SubMessage from protobuf.
      */
     decode: function (_bytes?: ByteSource): TestIsInitialized.SubMessage {
       return {};
     },
 
     /**
-     * Serializes a TestIsInitialized.SubMessage to JSON.
+     * Serializes TestIsInitialized.SubMessage to JSON.
      */
     encodeJSON: function (
       _msg?: Partial<TestIsInitialized.SubMessage>
@@ -69194,14 +69194,14 @@ export const TestIsInitialized = {
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from JSON.
+     * Deserializes TestIsInitialized.SubMessage from JSON.
      */
     decodeJSON: function (_json?: string): TestIsInitialized.SubMessage {
       return {};
     },
 
     /**
-     * Initializes a TestIsInitialized.SubMessage with all fields set to their default value.
+     * Initializes TestIsInitialized.SubMessage with all fields set to their default value.
      */
     initialize: function (): TestIsInitialized.SubMessage {
       return {};
@@ -69248,7 +69248,7 @@ export const TestIsInitialized = {
 
     SubGroup: {
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to protobuf.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to protobuf.
        */
       encode: function (
         msg: Partial<TestIsInitialized.SubMessage.SubGroup>
@@ -69260,7 +69260,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from protobuf.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -69272,7 +69272,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to JSON.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestIsInitialized.SubMessage.SubGroup>
@@ -69283,7 +69283,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from JSON.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from JSON.
        */
       decodeJSON: function (
         json: string
@@ -69295,7 +69295,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Initializes a TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
+       * Initializes TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
        */
       initialize: function (): TestIsInitialized.SubMessage.SubGroup {
         return {
@@ -69371,7 +69371,7 @@ export const TestIsInitialized = {
 
 export const TestDupFieldNumber = {
   /**
-   * Serializes a TestDupFieldNumber to protobuf.
+   * Serializes TestDupFieldNumber to protobuf.
    */
   encode: function (msg: Partial<TestDupFieldNumber>): Uint8Array {
     return TestDupFieldNumber._writeMessage(
@@ -69381,7 +69381,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from protobuf.
+   * Deserializes TestDupFieldNumber from protobuf.
    */
   decode: function (bytes: ByteSource): TestDupFieldNumber {
     return TestDupFieldNumber._readMessage(
@@ -69391,14 +69391,14 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Serializes a TestDupFieldNumber to JSON.
+   * Serializes TestDupFieldNumber to JSON.
    */
   encodeJSON: function (msg: Partial<TestDupFieldNumber>): string {
     return JSON.stringify(TestDupFieldNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from JSON.
+   * Deserializes TestDupFieldNumber from JSON.
    */
   decodeJSON: function (json: string): TestDupFieldNumber {
     return TestDupFieldNumber._readMessageJSON(
@@ -69408,7 +69408,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Initializes a TestDupFieldNumber with all fields set to their default value.
+   * Initializes TestDupFieldNumber with all fields set to their default value.
    */
   initialize: function (): TestDupFieldNumber {
     return {
@@ -69481,7 +69481,7 @@ export const TestDupFieldNumber = {
 
   Foo: {
     /**
-     * Serializes a TestDupFieldNumber.Foo to protobuf.
+     * Serializes TestDupFieldNumber.Foo to protobuf.
      */
     encode: function (msg: Partial<TestDupFieldNumber.Foo>): Uint8Array {
       return TestDupFieldNumber.Foo._writeMessage(
@@ -69491,7 +69491,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from protobuf.
+     * Deserializes TestDupFieldNumber.Foo from protobuf.
      */
     decode: function (bytes: ByteSource): TestDupFieldNumber.Foo {
       return TestDupFieldNumber.Foo._readMessage(
@@ -69501,14 +69501,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Foo to JSON.
+     * Serializes TestDupFieldNumber.Foo to JSON.
      */
     encodeJSON: function (msg: Partial<TestDupFieldNumber.Foo>): string {
       return JSON.stringify(TestDupFieldNumber.Foo._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from JSON.
+     * Deserializes TestDupFieldNumber.Foo from JSON.
      */
     decodeJSON: function (json: string): TestDupFieldNumber.Foo {
       return TestDupFieldNumber.Foo._readMessageJSON(
@@ -69518,7 +69518,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Foo with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Foo with all fields set to their default value.
      */
     initialize: function (): TestDupFieldNumber.Foo {
       return {
@@ -69592,7 +69592,7 @@ export const TestDupFieldNumber = {
 
   Bar: {
     /**
-     * Serializes a TestDupFieldNumber.Bar to protobuf.
+     * Serializes TestDupFieldNumber.Bar to protobuf.
      */
     encode: function (msg: Partial<TestDupFieldNumber.Bar>): Uint8Array {
       return TestDupFieldNumber.Bar._writeMessage(
@@ -69602,7 +69602,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from protobuf.
+     * Deserializes TestDupFieldNumber.Bar from protobuf.
      */
     decode: function (bytes: ByteSource): TestDupFieldNumber.Bar {
       return TestDupFieldNumber.Bar._readMessage(
@@ -69612,14 +69612,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Bar to JSON.
+     * Serializes TestDupFieldNumber.Bar to JSON.
      */
     encodeJSON: function (msg: Partial<TestDupFieldNumber.Bar>): string {
       return JSON.stringify(TestDupFieldNumber.Bar._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from JSON.
+     * Deserializes TestDupFieldNumber.Bar from JSON.
      */
     decodeJSON: function (json: string): TestDupFieldNumber.Bar {
       return TestDupFieldNumber.Bar._readMessageJSON(
@@ -69629,7 +69629,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Bar with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Bar with all fields set to their default value.
      */
     initialize: function (): TestDupFieldNumber.Bar {
       return {
@@ -69704,7 +69704,7 @@ export const TestDupFieldNumber = {
 
 export const TestEagerMessage = {
   /**
-   * Serializes a TestEagerMessage to protobuf.
+   * Serializes TestEagerMessage to protobuf.
    */
   encode: function (msg: Partial<TestEagerMessage>): Uint8Array {
     return TestEagerMessage._writeMessage(
@@ -69714,7 +69714,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Deserializes a TestEagerMessage from protobuf.
+   * Deserializes TestEagerMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestEagerMessage {
     return TestEagerMessage._readMessage(
@@ -69724,14 +69724,14 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Serializes a TestEagerMessage to JSON.
+   * Serializes TestEagerMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestEagerMessage>): string {
     return JSON.stringify(TestEagerMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestEagerMessage from JSON.
+   * Deserializes TestEagerMessage from JSON.
    */
   decodeJSON: function (json: string): TestEagerMessage {
     return TestEagerMessage._readMessageJSON(
@@ -69741,7 +69741,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Initializes a TestEagerMessage with all fields set to their default value.
+   * Initializes TestEagerMessage with all fields set to their default value.
    */
   initialize: function (): TestEagerMessage {
     return {
@@ -69820,7 +69820,7 @@ export const TestEagerMessage = {
 
 export const TestLazyMessage = {
   /**
-   * Serializes a TestLazyMessage to protobuf.
+   * Serializes TestLazyMessage to protobuf.
    */
   encode: function (msg: Partial<TestLazyMessage>): Uint8Array {
     return TestLazyMessage._writeMessage(
@@ -69830,7 +69830,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Deserializes a TestLazyMessage from protobuf.
+   * Deserializes TestLazyMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestLazyMessage {
     return TestLazyMessage._readMessage(
@@ -69840,14 +69840,14 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Serializes a TestLazyMessage to JSON.
+   * Serializes TestLazyMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestLazyMessage>): string {
     return JSON.stringify(TestLazyMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestLazyMessage from JSON.
+   * Deserializes TestLazyMessage from JSON.
    */
   decodeJSON: function (json: string): TestLazyMessage {
     return TestLazyMessage._readMessageJSON(
@@ -69857,7 +69857,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Initializes a TestLazyMessage with all fields set to their default value.
+   * Initializes TestLazyMessage with all fields set to their default value.
    */
   initialize: function (): TestLazyMessage {
     return {
@@ -69936,7 +69936,7 @@ export const TestLazyMessage = {
 
 export const TestNestedMessageHasBits = {
   /**
-   * Serializes a TestNestedMessageHasBits to protobuf.
+   * Serializes TestNestedMessageHasBits to protobuf.
    */
   encode: function (msg: Partial<TestNestedMessageHasBits>): Uint8Array {
     return TestNestedMessageHasBits._writeMessage(
@@ -69946,7 +69946,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from protobuf.
+   * Deserializes TestNestedMessageHasBits from protobuf.
    */
   decode: function (bytes: ByteSource): TestNestedMessageHasBits {
     return TestNestedMessageHasBits._readMessage(
@@ -69956,14 +69956,14 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Serializes a TestNestedMessageHasBits to JSON.
+   * Serializes TestNestedMessageHasBits to JSON.
    */
   encodeJSON: function (msg: Partial<TestNestedMessageHasBits>): string {
     return JSON.stringify(TestNestedMessageHasBits._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from JSON.
+   * Deserializes TestNestedMessageHasBits from JSON.
    */
   decodeJSON: function (json: string): TestNestedMessageHasBits {
     return TestNestedMessageHasBits._readMessageJSON(
@@ -69973,7 +69973,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Initializes a TestNestedMessageHasBits with all fields set to their default value.
+   * Initializes TestNestedMessageHasBits with all fields set to their default value.
    */
   initialize: function (): TestNestedMessageHasBits {
     return {
@@ -70066,7 +70066,7 @@ export const TestNestedMessageHasBits = {
 
   NestedMessage: {
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to protobuf.
+     * Serializes TestNestedMessageHasBits.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestNestedMessageHasBits.NestedMessage>
@@ -70078,7 +70078,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from protobuf.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -70090,7 +70090,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to JSON.
+     * Serializes TestNestedMessageHasBits.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestNestedMessageHasBits.NestedMessage>
@@ -70101,7 +70101,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from JSON.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from JSON.
      */
     decodeJSON: function (
       json: string
@@ -70113,7 +70113,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Initializes a TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
+     * Initializes TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestNestedMessageHasBits.NestedMessage {
       return {
@@ -70219,7 +70219,7 @@ export const TestNestedMessageHasBits = {
 
 export const TestCamelCaseFieldNames = {
   /**
-   * Serializes a TestCamelCaseFieldNames to protobuf.
+   * Serializes TestCamelCaseFieldNames to protobuf.
    */
   encode: function (msg: Partial<TestCamelCaseFieldNames>): Uint8Array {
     return TestCamelCaseFieldNames._writeMessage(
@@ -70229,7 +70229,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from protobuf.
+   * Deserializes TestCamelCaseFieldNames from protobuf.
    */
   decode: function (bytes: ByteSource): TestCamelCaseFieldNames {
     return TestCamelCaseFieldNames._readMessage(
@@ -70239,14 +70239,14 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Serializes a TestCamelCaseFieldNames to JSON.
+   * Serializes TestCamelCaseFieldNames to JSON.
    */
   encodeJSON: function (msg: Partial<TestCamelCaseFieldNames>): string {
     return JSON.stringify(TestCamelCaseFieldNames._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from JSON.
+   * Deserializes TestCamelCaseFieldNames from JSON.
    */
   decodeJSON: function (json: string): TestCamelCaseFieldNames {
     return TestCamelCaseFieldNames._readMessageJSON(
@@ -70256,7 +70256,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Initializes a TestCamelCaseFieldNames with all fields set to their default value.
+   * Initializes TestCamelCaseFieldNames with all fields set to their default value.
    */
   initialize: function (): TestCamelCaseFieldNames {
     return {
@@ -70515,7 +70515,7 @@ export const TestCamelCaseFieldNames = {
 
 export const TestFieldOrderings = {
   /**
-   * Serializes a TestFieldOrderings to protobuf.
+   * Serializes TestFieldOrderings to protobuf.
    */
   encode: function (msg: Partial<TestFieldOrderings>): Uint8Array {
     return TestFieldOrderings._writeMessage(
@@ -70525,7 +70525,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Deserializes a TestFieldOrderings from protobuf.
+   * Deserializes TestFieldOrderings from protobuf.
    */
   decode: function (bytes: ByteSource): TestFieldOrderings {
     return TestFieldOrderings._readMessage(
@@ -70535,14 +70535,14 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Serializes a TestFieldOrderings to JSON.
+   * Serializes TestFieldOrderings to JSON.
    */
   encodeJSON: function (msg: Partial<TestFieldOrderings>): string {
     return JSON.stringify(TestFieldOrderings._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestFieldOrderings from JSON.
+   * Deserializes TestFieldOrderings from JSON.
    */
   decodeJSON: function (json: string): TestFieldOrderings {
     return TestFieldOrderings._readMessageJSON(
@@ -70552,7 +70552,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Initializes a TestFieldOrderings with all fields set to their default value.
+   * Initializes TestFieldOrderings with all fields set to their default value.
    */
   initialize: function (): TestFieldOrderings {
     return {
@@ -70689,7 +70689,7 @@ export const TestFieldOrderings = {
 
   NestedMessage: {
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to protobuf.
+     * Serializes TestFieldOrderings.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestFieldOrderings.NestedMessage>
@@ -70701,7 +70701,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from protobuf.
+     * Deserializes TestFieldOrderings.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestFieldOrderings.NestedMessage {
       return TestFieldOrderings.NestedMessage._readMessage(
@@ -70711,7 +70711,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to JSON.
+     * Serializes TestFieldOrderings.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestFieldOrderings.NestedMessage>
@@ -70722,7 +70722,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from JSON.
+     * Deserializes TestFieldOrderings.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestFieldOrderings.NestedMessage {
       return TestFieldOrderings.NestedMessage._readMessageJSON(
@@ -70732,7 +70732,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Initializes a TestFieldOrderings.NestedMessage with all fields set to their default value.
+     * Initializes TestFieldOrderings.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestFieldOrderings.NestedMessage {
       return {
@@ -70822,7 +70822,7 @@ export const TestFieldOrderings = {
 
 export const TestExtensionOrderings1 = {
   /**
-   * Serializes a TestExtensionOrderings1 to protobuf.
+   * Serializes TestExtensionOrderings1 to protobuf.
    */
   encode: function (msg: Partial<TestExtensionOrderings1>): Uint8Array {
     return TestExtensionOrderings1._writeMessage(
@@ -70832,7 +70832,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from protobuf.
+   * Deserializes TestExtensionOrderings1 from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionOrderings1 {
     return TestExtensionOrderings1._readMessage(
@@ -70842,14 +70842,14 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings1 to JSON.
+   * Serializes TestExtensionOrderings1 to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionOrderings1>): string {
     return JSON.stringify(TestExtensionOrderings1._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from JSON.
+   * Deserializes TestExtensionOrderings1 from JSON.
    */
   decodeJSON: function (json: string): TestExtensionOrderings1 {
     return TestExtensionOrderings1._readMessageJSON(
@@ -70859,7 +70859,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings1 with all fields set to their default value.
+   * Initializes TestExtensionOrderings1 with all fields set to their default value.
    */
   initialize: function (): TestExtensionOrderings1 {
     return {
@@ -70933,7 +70933,7 @@ export const TestExtensionOrderings1 = {
 
 export const TestExtensionOrderings2 = {
   /**
-   * Serializes a TestExtensionOrderings2 to protobuf.
+   * Serializes TestExtensionOrderings2 to protobuf.
    */
   encode: function (msg: Partial<TestExtensionOrderings2>): Uint8Array {
     return TestExtensionOrderings2._writeMessage(
@@ -70943,7 +70943,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from protobuf.
+   * Deserializes TestExtensionOrderings2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionOrderings2 {
     return TestExtensionOrderings2._readMessage(
@@ -70953,14 +70953,14 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings2 to JSON.
+   * Serializes TestExtensionOrderings2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionOrderings2>): string {
     return JSON.stringify(TestExtensionOrderings2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from JSON.
+   * Deserializes TestExtensionOrderings2 from JSON.
    */
   decodeJSON: function (json: string): TestExtensionOrderings2 {
     return TestExtensionOrderings2._readMessageJSON(
@@ -70970,7 +70970,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings2 with all fields set to their default value.
+   * Initializes TestExtensionOrderings2 with all fields set to their default value.
    */
   initialize: function (): TestExtensionOrderings2 {
     return {
@@ -71043,7 +71043,7 @@ export const TestExtensionOrderings2 = {
 
   TestExtensionOrderings3: {
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
      */
     encode: function (
       msg: Partial<TestExtensionOrderings2.TestExtensionOrderings3>
@@ -71055,7 +71055,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -71067,7 +71067,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestExtensionOrderings2.TestExtensionOrderings3>
@@ -71078,7 +71078,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
      */
     decodeJSON: function (
       json: string
@@ -71090,7 +71090,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Initializes a TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
+     * Initializes TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
      */
     initialize: function (): TestExtensionOrderings2.TestExtensionOrderings3 {
       return {
@@ -71165,7 +71165,7 @@ export const TestExtensionOrderings2 = {
 
 export const TestExtremeDefaultValues = {
   /**
-   * Serializes a TestExtremeDefaultValues to protobuf.
+   * Serializes TestExtremeDefaultValues to protobuf.
    */
   encode: function (msg: Partial<TestExtremeDefaultValues>): Uint8Array {
     return TestExtremeDefaultValues._writeMessage(
@@ -71175,7 +71175,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from protobuf.
+   * Deserializes TestExtremeDefaultValues from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtremeDefaultValues {
     return TestExtremeDefaultValues._readMessage(
@@ -71185,14 +71185,14 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Serializes a TestExtremeDefaultValues to JSON.
+   * Serializes TestExtremeDefaultValues to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtremeDefaultValues>): string {
     return JSON.stringify(TestExtremeDefaultValues._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from JSON.
+   * Deserializes TestExtremeDefaultValues from JSON.
    */
   decodeJSON: function (json: string): TestExtremeDefaultValues {
     return TestExtremeDefaultValues._readMessageJSON(
@@ -71202,7 +71202,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Initializes a TestExtremeDefaultValues with all fields set to their default value.
+   * Initializes TestExtremeDefaultValues with all fields set to their default value.
    */
   initialize: function (): TestExtremeDefaultValues {
     return {
@@ -71669,7 +71669,7 @@ export const TestExtremeDefaultValues = {
 
 export const SparseEnumMessage = {
   /**
-   * Serializes a SparseEnumMessage to protobuf.
+   * Serializes SparseEnumMessage to protobuf.
    */
   encode: function (msg: Partial<SparseEnumMessage>): Uint8Array {
     return SparseEnumMessage._writeMessage(
@@ -71679,7 +71679,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Deserializes a SparseEnumMessage from protobuf.
+   * Deserializes SparseEnumMessage from protobuf.
    */
   decode: function (bytes: ByteSource): SparseEnumMessage {
     return SparseEnumMessage._readMessage(
@@ -71689,14 +71689,14 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Serializes a SparseEnumMessage to JSON.
+   * Serializes SparseEnumMessage to JSON.
    */
   encodeJSON: function (msg: Partial<SparseEnumMessage>): string {
     return JSON.stringify(SparseEnumMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SparseEnumMessage from JSON.
+   * Deserializes SparseEnumMessage from JSON.
    */
   decodeJSON: function (json: string): SparseEnumMessage {
     return SparseEnumMessage._readMessageJSON(
@@ -71706,7 +71706,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Initializes a SparseEnumMessage with all fields set to their default value.
+   * Initializes SparseEnumMessage with all fields set to their default value.
    */
   initialize: function (): SparseEnumMessage {
     return {
@@ -71780,14 +71780,14 @@ export const SparseEnumMessage = {
 
 export const OneString = {
   /**
-   * Serializes a OneString to protobuf.
+   * Serializes OneString to protobuf.
    */
   encode: function (msg: Partial<OneString>): Uint8Array {
     return OneString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneString from protobuf.
+   * Deserializes OneString from protobuf.
    */
   decode: function (bytes: ByteSource): OneString {
     return OneString._readMessage(
@@ -71797,21 +71797,21 @@ export const OneString = {
   },
 
   /**
-   * Serializes a OneString to JSON.
+   * Serializes OneString to JSON.
    */
   encodeJSON: function (msg: Partial<OneString>): string {
     return JSON.stringify(OneString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneString from JSON.
+   * Deserializes OneString from JSON.
    */
   decodeJSON: function (json: string): OneString {
     return OneString._readMessageJSON(OneString.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneString with all fields set to their default value.
+   * Initializes OneString with all fields set to their default value.
    */
   initialize: function (): OneString {
     return {
@@ -71879,14 +71879,14 @@ export const OneString = {
 
 export const MoreString = {
   /**
-   * Serializes a MoreString to protobuf.
+   * Serializes MoreString to protobuf.
    */
   encode: function (msg: Partial<MoreString>): Uint8Array {
     return MoreString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreString from protobuf.
+   * Deserializes MoreString from protobuf.
    */
   decode: function (bytes: ByteSource): MoreString {
     return MoreString._readMessage(
@@ -71896,14 +71896,14 @@ export const MoreString = {
   },
 
   /**
-   * Serializes a MoreString to JSON.
+   * Serializes MoreString to JSON.
    */
   encodeJSON: function (msg: Partial<MoreString>): string {
     return JSON.stringify(MoreString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreString from JSON.
+   * Deserializes MoreString from JSON.
    */
   decodeJSON: function (json: string): MoreString {
     return MoreString._readMessageJSON(
@@ -71913,7 +71913,7 @@ export const MoreString = {
   },
 
   /**
-   * Initializes a MoreString with all fields set to their default value.
+   * Initializes MoreString with all fields set to their default value.
    */
   initialize: function (): MoreString {
     return {
@@ -71981,14 +71981,14 @@ export const MoreString = {
 
 export const OneBytes = {
   /**
-   * Serializes a OneBytes to protobuf.
+   * Serializes OneBytes to protobuf.
    */
   encode: function (msg: Partial<OneBytes>): Uint8Array {
     return OneBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneBytes from protobuf.
+   * Deserializes OneBytes from protobuf.
    */
   decode: function (bytes: ByteSource): OneBytes {
     return OneBytes._readMessage(
@@ -71998,21 +71998,21 @@ export const OneBytes = {
   },
 
   /**
-   * Serializes a OneBytes to JSON.
+   * Serializes OneBytes to JSON.
    */
   encodeJSON: function (msg: Partial<OneBytes>): string {
     return JSON.stringify(OneBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneBytes from JSON.
+   * Deserializes OneBytes from JSON.
    */
   decodeJSON: function (json: string): OneBytes {
     return OneBytes._readMessageJSON(OneBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneBytes with all fields set to their default value.
+   * Initializes OneBytes with all fields set to their default value.
    */
   initialize: function (): OneBytes {
     return {
@@ -72080,14 +72080,14 @@ export const OneBytes = {
 
 export const MoreBytes = {
   /**
-   * Serializes a MoreBytes to protobuf.
+   * Serializes MoreBytes to protobuf.
    */
   encode: function (msg: Partial<MoreBytes>): Uint8Array {
     return MoreBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreBytes from protobuf.
+   * Deserializes MoreBytes from protobuf.
    */
   decode: function (bytes: ByteSource): MoreBytes {
     return MoreBytes._readMessage(
@@ -72097,21 +72097,21 @@ export const MoreBytes = {
   },
 
   /**
-   * Serializes a MoreBytes to JSON.
+   * Serializes MoreBytes to JSON.
    */
   encodeJSON: function (msg: Partial<MoreBytes>): string {
     return JSON.stringify(MoreBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreBytes from JSON.
+   * Deserializes MoreBytes from JSON.
    */
   decodeJSON: function (json: string): MoreBytes {
     return MoreBytes._readMessageJSON(MoreBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a MoreBytes with all fields set to their default value.
+   * Initializes MoreBytes with all fields set to their default value.
    */
   initialize: function (): MoreBytes {
     return {
@@ -72179,7 +72179,7 @@ export const MoreBytes = {
 
 export const Int32Message = {
   /**
-   * Serializes a Int32Message to protobuf.
+   * Serializes Int32Message to protobuf.
    */
   encode: function (msg: Partial<Int32Message>): Uint8Array {
     return Int32Message._writeMessage(
@@ -72189,7 +72189,7 @@ export const Int32Message = {
   },
 
   /**
-   * Deserializes a Int32Message from protobuf.
+   * Deserializes Int32Message from protobuf.
    */
   decode: function (bytes: ByteSource): Int32Message {
     return Int32Message._readMessage(
@@ -72199,14 +72199,14 @@ export const Int32Message = {
   },
 
   /**
-   * Serializes a Int32Message to JSON.
+   * Serializes Int32Message to JSON.
    */
   encodeJSON: function (msg: Partial<Int32Message>): string {
     return JSON.stringify(Int32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Message from JSON.
+   * Deserializes Int32Message from JSON.
    */
   decodeJSON: function (json: string): Int32Message {
     return Int32Message._readMessageJSON(
@@ -72216,7 +72216,7 @@ export const Int32Message = {
   },
 
   /**
-   * Initializes a Int32Message with all fields set to their default value.
+   * Initializes Int32Message with all fields set to their default value.
    */
   initialize: function (): Int32Message {
     return {
@@ -72287,7 +72287,7 @@ export const Int32Message = {
 
 export const Uint32Message = {
   /**
-   * Serializes a Uint32Message to protobuf.
+   * Serializes Uint32Message to protobuf.
    */
   encode: function (msg: Partial<Uint32Message>): Uint8Array {
     return Uint32Message._writeMessage(
@@ -72297,7 +72297,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Deserializes a Uint32Message from protobuf.
+   * Deserializes Uint32Message from protobuf.
    */
   decode: function (bytes: ByteSource): Uint32Message {
     return Uint32Message._readMessage(
@@ -72307,14 +72307,14 @@ export const Uint32Message = {
   },
 
   /**
-   * Serializes a Uint32Message to JSON.
+   * Serializes Uint32Message to JSON.
    */
   encodeJSON: function (msg: Partial<Uint32Message>): string {
     return JSON.stringify(Uint32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint32Message from JSON.
+   * Deserializes Uint32Message from JSON.
    */
   decodeJSON: function (json: string): Uint32Message {
     return Uint32Message._readMessageJSON(
@@ -72324,7 +72324,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Initializes a Uint32Message with all fields set to their default value.
+   * Initializes Uint32Message with all fields set to their default value.
    */
   initialize: function (): Uint32Message {
     return {
@@ -72395,7 +72395,7 @@ export const Uint32Message = {
 
 export const Int64Message = {
   /**
-   * Serializes a Int64Message to protobuf.
+   * Serializes Int64Message to protobuf.
    */
   encode: function (msg: Partial<Int64Message>): Uint8Array {
     return Int64Message._writeMessage(
@@ -72405,7 +72405,7 @@ export const Int64Message = {
   },
 
   /**
-   * Deserializes a Int64Message from protobuf.
+   * Deserializes Int64Message from protobuf.
    */
   decode: function (bytes: ByteSource): Int64Message {
     return Int64Message._readMessage(
@@ -72415,14 +72415,14 @@ export const Int64Message = {
   },
 
   /**
-   * Serializes a Int64Message to JSON.
+   * Serializes Int64Message to JSON.
    */
   encodeJSON: function (msg: Partial<Int64Message>): string {
     return JSON.stringify(Int64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Message from JSON.
+   * Deserializes Int64Message from JSON.
    */
   decodeJSON: function (json: string): Int64Message {
     return Int64Message._readMessageJSON(
@@ -72432,7 +72432,7 @@ export const Int64Message = {
   },
 
   /**
-   * Initializes a Int64Message with all fields set to their default value.
+   * Initializes Int64Message with all fields set to their default value.
    */
   initialize: function (): Int64Message {
     return {
@@ -72503,7 +72503,7 @@ export const Int64Message = {
 
 export const Uint64Message = {
   /**
-   * Serializes a Uint64Message to protobuf.
+   * Serializes Uint64Message to protobuf.
    */
   encode: function (msg: Partial<Uint64Message>): Uint8Array {
     return Uint64Message._writeMessage(
@@ -72513,7 +72513,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Deserializes a Uint64Message from protobuf.
+   * Deserializes Uint64Message from protobuf.
    */
   decode: function (bytes: ByteSource): Uint64Message {
     return Uint64Message._readMessage(
@@ -72523,14 +72523,14 @@ export const Uint64Message = {
   },
 
   /**
-   * Serializes a Uint64Message to JSON.
+   * Serializes Uint64Message to JSON.
    */
   encodeJSON: function (msg: Partial<Uint64Message>): string {
     return JSON.stringify(Uint64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint64Message from JSON.
+   * Deserializes Uint64Message from JSON.
    */
   decodeJSON: function (json: string): Uint64Message {
     return Uint64Message._readMessageJSON(
@@ -72540,7 +72540,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Initializes a Uint64Message with all fields set to their default value.
+   * Initializes Uint64Message with all fields set to their default value.
    */
   initialize: function (): Uint64Message {
     return {
@@ -72611,14 +72611,14 @@ export const Uint64Message = {
 
 export const BoolMessage = {
   /**
-   * Serializes a BoolMessage to protobuf.
+   * Serializes BoolMessage to protobuf.
    */
   encode: function (msg: Partial<BoolMessage>): Uint8Array {
     return BoolMessage._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolMessage from protobuf.
+   * Deserializes BoolMessage from protobuf.
    */
   decode: function (bytes: ByteSource): BoolMessage {
     return BoolMessage._readMessage(
@@ -72628,14 +72628,14 @@ export const BoolMessage = {
   },
 
   /**
-   * Serializes a BoolMessage to JSON.
+   * Serializes BoolMessage to JSON.
    */
   encodeJSON: function (msg: Partial<BoolMessage>): string {
     return JSON.stringify(BoolMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolMessage from JSON.
+   * Deserializes BoolMessage from JSON.
    */
   decodeJSON: function (json: string): BoolMessage {
     return BoolMessage._readMessageJSON(
@@ -72645,7 +72645,7 @@ export const BoolMessage = {
   },
 
   /**
-   * Initializes a BoolMessage with all fields set to their default value.
+   * Initializes BoolMessage with all fields set to their default value.
    */
   initialize: function (): BoolMessage {
     return {
@@ -72713,14 +72713,14 @@ export const BoolMessage = {
 
 export const TestOneof = {
   /**
-   * Serializes a TestOneof to protobuf.
+   * Serializes TestOneof to protobuf.
    */
   encode: function (msg: Partial<TestOneof>): Uint8Array {
     return TestOneof._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof from protobuf.
+   * Deserializes TestOneof from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof {
     return TestOneof._readMessage(
@@ -72730,21 +72730,21 @@ export const TestOneof = {
   },
 
   /**
-   * Serializes a TestOneof to JSON.
+   * Serializes TestOneof to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof>): string {
     return JSON.stringify(TestOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof from JSON.
+   * Deserializes TestOneof from JSON.
    */
   decodeJSON: function (json: string): TestOneof {
     return TestOneof._readMessageJSON(TestOneof.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestOneof with all fields set to their default value.
+   * Initializes TestOneof with all fields set to their default value.
    */
   initialize: function (): TestOneof {
     return {
@@ -72844,7 +72844,7 @@ export const TestOneof = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof.FooGroup to protobuf.
+     * Serializes TestOneof.FooGroup to protobuf.
      */
     encode: function (msg: Partial<TestOneof.FooGroup>): Uint8Array {
       return TestOneof.FooGroup._writeMessage(
@@ -72854,7 +72854,7 @@ export const TestOneof = {
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from protobuf.
+     * Deserializes TestOneof.FooGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof.FooGroup {
       return TestOneof.FooGroup._readMessage(
@@ -72864,14 +72864,14 @@ export const TestOneof = {
     },
 
     /**
-     * Serializes a TestOneof.FooGroup to JSON.
+     * Serializes TestOneof.FooGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof.FooGroup>): string {
       return JSON.stringify(TestOneof.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from JSON.
+     * Deserializes TestOneof.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneof.FooGroup {
       return TestOneof.FooGroup._readMessageJSON(
@@ -72881,7 +72881,7 @@ export const TestOneof = {
     },
 
     /**
-     * Initializes a TestOneof.FooGroup with all fields set to their default value.
+     * Initializes TestOneof.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneof.FooGroup {
       return {
@@ -72971,7 +72971,7 @@ export const TestOneof = {
 
 export const TestOneofBackwardsCompatible = {
   /**
-   * Serializes a TestOneofBackwardsCompatible to protobuf.
+   * Serializes TestOneofBackwardsCompatible to protobuf.
    */
   encode: function (msg: Partial<TestOneofBackwardsCompatible>): Uint8Array {
     return TestOneofBackwardsCompatible._writeMessage(
@@ -72981,7 +72981,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from protobuf.
+   * Deserializes TestOneofBackwardsCompatible from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneofBackwardsCompatible {
     return TestOneofBackwardsCompatible._readMessage(
@@ -72991,14 +72991,14 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Serializes a TestOneofBackwardsCompatible to JSON.
+   * Serializes TestOneofBackwardsCompatible to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneofBackwardsCompatible>): string {
     return JSON.stringify(TestOneofBackwardsCompatible._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from JSON.
+   * Deserializes TestOneofBackwardsCompatible from JSON.
    */
   decodeJSON: function (json: string): TestOneofBackwardsCompatible {
     return TestOneofBackwardsCompatible._readMessageJSON(
@@ -73008,7 +73008,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Initializes a TestOneofBackwardsCompatible with all fields set to their default value.
+   * Initializes TestOneofBackwardsCompatible with all fields set to their default value.
    */
   initialize: function (): TestOneofBackwardsCompatible {
     return {
@@ -73116,7 +73116,7 @@ export const TestOneofBackwardsCompatible = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to protobuf.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestOneofBackwardsCompatible.FooGroup>
@@ -73128,7 +73128,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from protobuf.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -73140,7 +73140,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to JSON.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestOneofBackwardsCompatible.FooGroup>
@@ -73151,7 +73151,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from JSON.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneofBackwardsCompatible.FooGroup {
       return TestOneofBackwardsCompatible.FooGroup._readMessageJSON(
@@ -73161,7 +73161,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Initializes a TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
+     * Initializes TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneofBackwardsCompatible.FooGroup {
       return {
@@ -73251,14 +73251,14 @@ export const TestOneofBackwardsCompatible = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg: Partial<TestOneof2>): Uint8Array {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof2 {
     return TestOneof2._readMessage(
@@ -73268,14 +73268,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof2>): string {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json: string): TestOneof2 {
     return TestOneof2._readMessageJSON(
@@ -73285,7 +73285,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function (): TestOneof2 {
     return {
@@ -73704,7 +73704,7 @@ export const TestOneof2 = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof2.FooGroup to protobuf.
+     * Serializes TestOneof2.FooGroup to protobuf.
      */
     encode: function (msg: Partial<TestOneof2.FooGroup>): Uint8Array {
       return TestOneof2.FooGroup._writeMessage(
@@ -73714,7 +73714,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from protobuf.
+     * Deserializes TestOneof2.FooGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof2.FooGroup {
       return TestOneof2.FooGroup._readMessage(
@@ -73724,14 +73724,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.FooGroup to JSON.
+     * Serializes TestOneof2.FooGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof2.FooGroup>): string {
       return JSON.stringify(TestOneof2.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from JSON.
+     * Deserializes TestOneof2.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneof2.FooGroup {
       return TestOneof2.FooGroup._readMessageJSON(
@@ -73741,7 +73741,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.FooGroup with all fields set to their default value.
+     * Initializes TestOneof2.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneof2.FooGroup {
       return {
@@ -73830,7 +73830,7 @@ export const TestOneof2 = {
 
   NestedMessage: {
     /**
-     * Serializes a TestOneof2.NestedMessage to protobuf.
+     * Serializes TestOneof2.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestOneof2.NestedMessage>): Uint8Array {
       return TestOneof2.NestedMessage._writeMessage(
@@ -73840,7 +73840,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from protobuf.
+     * Deserializes TestOneof2.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof2.NestedMessage {
       return TestOneof2.NestedMessage._readMessage(
@@ -73850,14 +73850,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.NestedMessage to JSON.
+     * Serializes TestOneof2.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof2.NestedMessage>): string {
       return JSON.stringify(TestOneof2.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from JSON.
+     * Deserializes TestOneof2.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestOneof2.NestedMessage {
       return TestOneof2.NestedMessage._readMessageJSON(
@@ -73867,7 +73867,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.NestedMessage with all fields set to their default value.
+     * Initializes TestOneof2.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestOneof2.NestedMessage {
       return {
@@ -73957,7 +73957,7 @@ export const TestOneof2 = {
 
 export const TestRequiredOneof = {
   /**
-   * Serializes a TestRequiredOneof to protobuf.
+   * Serializes TestRequiredOneof to protobuf.
    */
   encode: function (msg: Partial<TestRequiredOneof>): Uint8Array {
     return TestRequiredOneof._writeMessage(
@@ -73967,7 +73967,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Deserializes a TestRequiredOneof from protobuf.
+   * Deserializes TestRequiredOneof from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredOneof {
     return TestRequiredOneof._readMessage(
@@ -73977,14 +73977,14 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Serializes a TestRequiredOneof to JSON.
+   * Serializes TestRequiredOneof to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredOneof>): string {
     return JSON.stringify(TestRequiredOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredOneof from JSON.
+   * Deserializes TestRequiredOneof from JSON.
    */
   decodeJSON: function (json: string): TestRequiredOneof {
     return TestRequiredOneof._readMessageJSON(
@@ -73994,7 +73994,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Initializes a TestRequiredOneof with all fields set to their default value.
+   * Initializes TestRequiredOneof with all fields set to their default value.
    */
   initialize: function (): TestRequiredOneof {
     return {
@@ -74109,7 +74109,7 @@ export const TestRequiredOneof = {
 
   NestedMessage: {
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to protobuf.
+     * Serializes TestRequiredOneof.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestRequiredOneof.NestedMessage>
@@ -74121,7 +74121,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from protobuf.
+     * Deserializes TestRequiredOneof.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestRequiredOneof.NestedMessage {
       return TestRequiredOneof.NestedMessage._readMessage(
@@ -74131,7 +74131,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to JSON.
+     * Serializes TestRequiredOneof.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestRequiredOneof.NestedMessage>
@@ -74142,7 +74142,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from JSON.
+     * Deserializes TestRequiredOneof.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestRequiredOneof.NestedMessage {
       return TestRequiredOneof.NestedMessage._readMessageJSON(
@@ -74152,7 +74152,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Initializes a TestRequiredOneof.NestedMessage with all fields set to their default value.
+     * Initializes TestRequiredOneof.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestRequiredOneof.NestedMessage {
       return {
@@ -74227,7 +74227,7 @@ export const TestRequiredOneof = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestPackedTypes>): Uint8Array {
     return TestPackedTypes._writeMessage(
@@ -74237,7 +74237,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestPackedTypes {
     return TestPackedTypes._readMessage(
@@ -74247,14 +74247,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestPackedTypes>): string {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestPackedTypes {
     return TestPackedTypes._readMessageJSON(
@@ -74264,7 +74264,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function (): TestPackedTypes {
     return {
@@ -74548,7 +74548,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestUnpackedTypes>): Uint8Array {
     return TestUnpackedTypes._writeMessage(
@@ -74558,7 +74558,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestUnpackedTypes {
     return TestUnpackedTypes._readMessage(
@@ -74568,14 +74568,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestUnpackedTypes>): string {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestUnpackedTypes {
     return TestUnpackedTypes._readMessageJSON(
@@ -74585,7 +74585,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function (): TestUnpackedTypes {
     return {
@@ -74869,35 +74869,35 @@ export const TestUnpackedTypes = {
 
 export const TestPackedExtensions = {
   /**
-   * Serializes a TestPackedExtensions to protobuf.
+   * Serializes TestPackedExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestPackedExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPackedExtensions from protobuf.
+   * Deserializes TestPackedExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestPackedExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestPackedExtensions to JSON.
+   * Serializes TestPackedExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestPackedExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPackedExtensions from JSON.
+   * Deserializes TestPackedExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestPackedExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestPackedExtensions with all fields set to their default value.
+   * Initializes TestPackedExtensions with all fields set to their default value.
    */
   initialize: function (): TestPackedExtensions {
     return {};
@@ -74945,35 +74945,35 @@ export const TestPackedExtensions = {
 
 export const TestUnpackedExtensions = {
   /**
-   * Serializes a TestUnpackedExtensions to protobuf.
+   * Serializes TestUnpackedExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestUnpackedExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from protobuf.
+   * Deserializes TestUnpackedExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestUnpackedExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestUnpackedExtensions to JSON.
+   * Serializes TestUnpackedExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestUnpackedExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from JSON.
+   * Deserializes TestUnpackedExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestUnpackedExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestUnpackedExtensions with all fields set to their default value.
+   * Initializes TestUnpackedExtensions with all fields set to their default value.
    */
   initialize: function (): TestUnpackedExtensions {
     return {};
@@ -75021,7 +75021,7 @@ export const TestUnpackedExtensions = {
 
 export const TestDynamicExtensions = {
   /**
-   * Serializes a TestDynamicExtensions to protobuf.
+   * Serializes TestDynamicExtensions to protobuf.
    */
   encode: function (msg: Partial<TestDynamicExtensions>): Uint8Array {
     return TestDynamicExtensions._writeMessage(
@@ -75031,7 +75031,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from protobuf.
+   * Deserializes TestDynamicExtensions from protobuf.
    */
   decode: function (bytes: ByteSource): TestDynamicExtensions {
     return TestDynamicExtensions._readMessage(
@@ -75041,14 +75041,14 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Serializes a TestDynamicExtensions to JSON.
+   * Serializes TestDynamicExtensions to JSON.
    */
   encodeJSON: function (msg: Partial<TestDynamicExtensions>): string {
     return JSON.stringify(TestDynamicExtensions._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from JSON.
+   * Deserializes TestDynamicExtensions from JSON.
    */
   decodeJSON: function (json: string): TestDynamicExtensions {
     return TestDynamicExtensions._readMessageJSON(
@@ -75058,7 +75058,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Initializes a TestDynamicExtensions with all fields set to their default value.
+   * Initializes TestDynamicExtensions with all fields set to their default value.
    */
   initialize: function (): TestDynamicExtensions {
     return {
@@ -75310,7 +75310,7 @@ export const TestDynamicExtensions = {
 
   DynamicMessageType: {
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to protobuf.
+     * Serializes TestDynamicExtensions.DynamicMessageType to protobuf.
      */
     encode: function (
       msg: Partial<TestDynamicExtensions.DynamicMessageType>
@@ -75322,7 +75322,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from protobuf.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -75334,7 +75334,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to JSON.
+     * Serializes TestDynamicExtensions.DynamicMessageType to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestDynamicExtensions.DynamicMessageType>
@@ -75345,7 +75345,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from JSON.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from JSON.
      */
     decodeJSON: function (
       json: string
@@ -75357,7 +75357,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Initializes a TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
+     * Initializes TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
      */
     initialize: function (): TestDynamicExtensions.DynamicMessageType {
       return {
@@ -75432,7 +75432,7 @@ export const TestDynamicExtensions = {
 
 export const TestRepeatedScalarDifferentTagSizes = {
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to protobuf.
+   * Serializes TestRepeatedScalarDifferentTagSizes to protobuf.
    */
   encode: function (
     msg: Partial<TestRepeatedScalarDifferentTagSizes>
@@ -75444,7 +75444,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from protobuf.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from protobuf.
    */
   decode: function (bytes: ByteSource): TestRepeatedScalarDifferentTagSizes {
     return TestRepeatedScalarDifferentTagSizes._readMessage(
@@ -75454,7 +75454,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to JSON.
+   * Serializes TestRepeatedScalarDifferentTagSizes to JSON.
    */
   encodeJSON: function (
     msg: Partial<TestRepeatedScalarDifferentTagSizes>
@@ -75465,7 +75465,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from JSON.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from JSON.
    */
   decodeJSON: function (json: string): TestRepeatedScalarDifferentTagSizes {
     return TestRepeatedScalarDifferentTagSizes._readMessageJSON(
@@ -75475,7 +75475,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Initializes a TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
+   * Initializes TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
    */
   initialize: function (): TestRepeatedScalarDifferentTagSizes {
     return {
@@ -75633,7 +75633,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
 
 export const TestParsingMerge = {
   /**
-   * Serializes a TestParsingMerge to protobuf.
+   * Serializes TestParsingMerge to protobuf.
    */
   encode: function (msg: Partial<TestParsingMerge>): Uint8Array {
     return TestParsingMerge._writeMessage(
@@ -75643,7 +75643,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Deserializes a TestParsingMerge from protobuf.
+   * Deserializes TestParsingMerge from protobuf.
    */
   decode: function (bytes: ByteSource): TestParsingMerge {
     return TestParsingMerge._readMessage(
@@ -75653,14 +75653,14 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Serializes a TestParsingMerge to JSON.
+   * Serializes TestParsingMerge to JSON.
    */
   encodeJSON: function (msg: Partial<TestParsingMerge>): string {
     return JSON.stringify(TestParsingMerge._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestParsingMerge from JSON.
+   * Deserializes TestParsingMerge from JSON.
    */
   decodeJSON: function (json: string): TestParsingMerge {
     return TestParsingMerge._readMessageJSON(
@@ -75670,7 +75670,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Initializes a TestParsingMerge with all fields set to their default value.
+   * Initializes TestParsingMerge with all fields set to their default value.
    */
   initialize: function (): TestParsingMerge {
     return {
@@ -75799,7 +75799,7 @@ export const TestParsingMerge = {
 
   RepeatedFieldsGenerator: {
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to protobuf.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.RepeatedFieldsGenerator>
@@ -75811,7 +75811,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from protobuf.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -75823,7 +75823,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to JSON.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.RepeatedFieldsGenerator>
@@ -75834,7 +75834,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from JSON.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from JSON.
      */
     decodeJSON: function (
       json: string
@@ -75846,7 +75846,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.RepeatedFieldsGenerator {
       return {
@@ -76029,7 +76029,7 @@ export const TestParsingMerge = {
 
     Group1: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
        */
       encode: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group1>
@@ -76041,7 +76041,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -76053,7 +76053,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group1>
@@ -76064,7 +76064,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
        */
       decodeJSON: function (
         json: string
@@ -76076,7 +76076,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
        */
       initialize: function (): TestParsingMerge.RepeatedFieldsGenerator.Group1 {
         return {
@@ -76155,7 +76155,7 @@ export const TestParsingMerge = {
 
     Group2: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
        */
       encode: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group2>
@@ -76167,7 +76167,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -76179,7 +76179,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group2>
@@ -76190,7 +76190,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
        */
       decodeJSON: function (
         json: string
@@ -76202,7 +76202,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
        */
       initialize: function (): TestParsingMerge.RepeatedFieldsGenerator.Group2 {
         return {
@@ -76282,7 +76282,7 @@ export const TestParsingMerge = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to protobuf.
+     * Serializes TestParsingMerge.OptionalGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.OptionalGroup>
@@ -76294,7 +76294,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from protobuf.
+     * Deserializes TestParsingMerge.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestParsingMerge.OptionalGroup {
       return TestParsingMerge.OptionalGroup._readMessage(
@@ -76304,7 +76304,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to JSON.
+     * Serializes TestParsingMerge.OptionalGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.OptionalGroup>
@@ -76315,7 +76315,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from JSON.
+     * Deserializes TestParsingMerge.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestParsingMerge.OptionalGroup {
       return TestParsingMerge.OptionalGroup._readMessageJSON(
@@ -76325,7 +76325,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.OptionalGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.OptionalGroup {
       return {
@@ -76414,7 +76414,7 @@ export const TestParsingMerge = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to protobuf.
+     * Serializes TestParsingMerge.RepeatedGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.RepeatedGroup>
@@ -76426,7 +76426,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from protobuf.
+     * Deserializes TestParsingMerge.RepeatedGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestParsingMerge.RepeatedGroup {
       return TestParsingMerge.RepeatedGroup._readMessage(
@@ -76436,7 +76436,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to JSON.
+     * Serializes TestParsingMerge.RepeatedGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.RepeatedGroup>
@@ -76447,7 +76447,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from JSON.
+     * Deserializes TestParsingMerge.RepeatedGroup from JSON.
      */
     decodeJSON: function (json: string): TestParsingMerge.RepeatedGroup {
       return TestParsingMerge.RepeatedGroup._readMessageJSON(
@@ -76457,7 +76457,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedGroup with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.RepeatedGroup {
       return {
@@ -76547,7 +76547,7 @@ export const TestParsingMerge = {
 
 export const TestCommentInjectionMessage = {
   /**
-   * Serializes a TestCommentInjectionMessage to protobuf.
+   * Serializes TestCommentInjectionMessage to protobuf.
    */
   encode: function (msg: Partial<TestCommentInjectionMessage>): Uint8Array {
     return TestCommentInjectionMessage._writeMessage(
@@ -76557,7 +76557,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from protobuf.
+   * Deserializes TestCommentInjectionMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestCommentInjectionMessage {
     return TestCommentInjectionMessage._readMessage(
@@ -76567,14 +76567,14 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Serializes a TestCommentInjectionMessage to JSON.
+   * Serializes TestCommentInjectionMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestCommentInjectionMessage>): string {
     return JSON.stringify(TestCommentInjectionMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from JSON.
+   * Deserializes TestCommentInjectionMessage from JSON.
    */
   decodeJSON: function (json: string): TestCommentInjectionMessage {
     return TestCommentInjectionMessage._readMessageJSON(
@@ -76584,7 +76584,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Initializes a TestCommentInjectionMessage with all fields set to their default value.
+   * Initializes TestCommentInjectionMessage with all fields set to their default value.
    */
   initialize: function (): TestCommentInjectionMessage {
     return {
@@ -76658,35 +76658,35 @@ export const TestCommentInjectionMessage = {
 
 export const FooRequest = {
   /**
-   * Serializes a FooRequest to protobuf.
+   * Serializes FooRequest to protobuf.
    */
   encode: function (_msg?: Partial<FooRequest>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooRequest from protobuf.
+   * Deserializes FooRequest from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooRequest {
     return {};
   },
 
   /**
-   * Serializes a FooRequest to JSON.
+   * Serializes FooRequest to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooRequest>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooRequest from JSON.
+   * Deserializes FooRequest from JSON.
    */
   decodeJSON: function (_json?: string): FooRequest {
     return {};
   },
 
   /**
-   * Initializes a FooRequest with all fields set to their default value.
+   * Initializes FooRequest with all fields set to their default value.
    */
   initialize: function (): FooRequest {
     return {};
@@ -76728,35 +76728,35 @@ export const FooRequest = {
 
 export const FooResponse = {
   /**
-   * Serializes a FooResponse to protobuf.
+   * Serializes FooResponse to protobuf.
    */
   encode: function (_msg?: Partial<FooResponse>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooResponse from protobuf.
+   * Deserializes FooResponse from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooResponse {
     return {};
   },
 
   /**
-   * Serializes a FooResponse to JSON.
+   * Serializes FooResponse to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooResponse>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooResponse from JSON.
+   * Deserializes FooResponse from JSON.
    */
   decodeJSON: function (_json?: string): FooResponse {
     return {};
   },
 
   /**
-   * Initializes a FooResponse with all fields set to their default value.
+   * Initializes FooResponse with all fields set to their default value.
    */
   initialize: function (): FooResponse {
     return {};
@@ -76801,35 +76801,35 @@ export const FooResponse = {
 
 export const FooClientMessage = {
   /**
-   * Serializes a FooClientMessage to protobuf.
+   * Serializes FooClientMessage to protobuf.
    */
   encode: function (_msg?: Partial<FooClientMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooClientMessage from protobuf.
+   * Deserializes FooClientMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooClientMessage {
     return {};
   },
 
   /**
-   * Serializes a FooClientMessage to JSON.
+   * Serializes FooClientMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooClientMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooClientMessage from JSON.
+   * Deserializes FooClientMessage from JSON.
    */
   decodeJSON: function (_json?: string): FooClientMessage {
     return {};
   },
 
   /**
-   * Initializes a FooClientMessage with all fields set to their default value.
+   * Initializes FooClientMessage with all fields set to their default value.
    */
   initialize: function (): FooClientMessage {
     return {};
@@ -76877,35 +76877,35 @@ export const FooClientMessage = {
 
 export const FooServerMessage = {
   /**
-   * Serializes a FooServerMessage to protobuf.
+   * Serializes FooServerMessage to protobuf.
    */
   encode: function (_msg?: Partial<FooServerMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooServerMessage from protobuf.
+   * Deserializes FooServerMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooServerMessage {
     return {};
   },
 
   /**
-   * Serializes a FooServerMessage to JSON.
+   * Serializes FooServerMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooServerMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooServerMessage from JSON.
+   * Deserializes FooServerMessage from JSON.
    */
   decodeJSON: function (_json?: string): FooServerMessage {
     return {};
   },
 
   /**
-   * Initializes a FooServerMessage with all fields set to their default value.
+   * Initializes FooServerMessage with all fields set to their default value.
    */
   initialize: function (): FooServerMessage {
     return {};
@@ -76953,35 +76953,35 @@ export const FooServerMessage = {
 
 export const BarRequest = {
   /**
-   * Serializes a BarRequest to protobuf.
+   * Serializes BarRequest to protobuf.
    */
   encode: function (_msg?: Partial<BarRequest>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarRequest from protobuf.
+   * Deserializes BarRequest from protobuf.
    */
   decode: function (_bytes?: ByteSource): BarRequest {
     return {};
   },
 
   /**
-   * Serializes a BarRequest to JSON.
+   * Serializes BarRequest to JSON.
    */
   encodeJSON: function (_msg?: Partial<BarRequest>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarRequest from JSON.
+   * Deserializes BarRequest from JSON.
    */
   decodeJSON: function (_json?: string): BarRequest {
     return {};
   },
 
   /**
-   * Initializes a BarRequest with all fields set to their default value.
+   * Initializes BarRequest with all fields set to their default value.
    */
   initialize: function (): BarRequest {
     return {};
@@ -77023,35 +77023,35 @@ export const BarRequest = {
 
 export const BarResponse = {
   /**
-   * Serializes a BarResponse to protobuf.
+   * Serializes BarResponse to protobuf.
    */
   encode: function (_msg?: Partial<BarResponse>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarResponse from protobuf.
+   * Deserializes BarResponse from protobuf.
    */
   decode: function (_bytes?: ByteSource): BarResponse {
     return {};
   },
 
   /**
-   * Serializes a BarResponse to JSON.
+   * Serializes BarResponse to JSON.
    */
   encodeJSON: function (_msg?: Partial<BarResponse>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarResponse from JSON.
+   * Deserializes BarResponse from JSON.
    */
   decodeJSON: function (_json?: string): BarResponse {
     return {};
   },
 
   /**
-   * Initializes a BarResponse with all fields set to their default value.
+   * Initializes BarResponse with all fields set to their default value.
    */
   initialize: function (): BarResponse {
     return {};
@@ -77096,7 +77096,7 @@ export const BarResponse = {
 
 export const TestJsonName = {
   /**
-   * Serializes a TestJsonName to protobuf.
+   * Serializes TestJsonName to protobuf.
    */
   encode: function (msg: Partial<TestJsonName>): Uint8Array {
     return TestJsonName._writeMessage(
@@ -77106,7 +77106,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Deserializes a TestJsonName from protobuf.
+   * Deserializes TestJsonName from protobuf.
    */
   decode: function (bytes: ByteSource): TestJsonName {
     return TestJsonName._readMessage(
@@ -77116,14 +77116,14 @@ export const TestJsonName = {
   },
 
   /**
-   * Serializes a TestJsonName to JSON.
+   * Serializes TestJsonName to JSON.
    */
   encodeJSON: function (msg: Partial<TestJsonName>): string {
     return JSON.stringify(TestJsonName._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestJsonName from JSON.
+   * Deserializes TestJsonName from JSON.
    */
   decodeJSON: function (json: string): TestJsonName {
     return TestJsonName._readMessageJSON(
@@ -77133,7 +77133,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Initializes a TestJsonName with all fields set to their default value.
+   * Initializes TestJsonName with all fields set to their default value.
    */
   initialize: function (): TestJsonName {
     return {
@@ -77294,7 +77294,7 @@ export const TestJsonName = {
 
 export const TestHugeFieldNumbers = {
   /**
-   * Serializes a TestHugeFieldNumbers to protobuf.
+   * Serializes TestHugeFieldNumbers to protobuf.
    */
   encode: function (msg: Partial<TestHugeFieldNumbers>): Uint8Array {
     return TestHugeFieldNumbers._writeMessage(
@@ -77304,7 +77304,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from protobuf.
+   * Deserializes TestHugeFieldNumbers from protobuf.
    */
   decode: function (bytes: ByteSource): TestHugeFieldNumbers {
     return TestHugeFieldNumbers._readMessage(
@@ -77314,14 +77314,14 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Serializes a TestHugeFieldNumbers to JSON.
+   * Serializes TestHugeFieldNumbers to JSON.
    */
   encodeJSON: function (msg: Partial<TestHugeFieldNumbers>): string {
     return JSON.stringify(TestHugeFieldNumbers._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from JSON.
+   * Deserializes TestHugeFieldNumbers from JSON.
    */
   decodeJSON: function (json: string): TestHugeFieldNumbers {
     return TestHugeFieldNumbers._readMessageJSON(
@@ -77331,7 +77331,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Initializes a TestHugeFieldNumbers with all fields set to their default value.
+   * Initializes TestHugeFieldNumbers with all fields set to their default value.
    */
   initialize: function (): TestHugeFieldNumbers {
     return {
@@ -77630,7 +77630,7 @@ export const TestHugeFieldNumbers = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to protobuf.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestHugeFieldNumbers.OptionalGroup>
@@ -77642,7 +77642,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from protobuf.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestHugeFieldNumbers.OptionalGroup {
       return TestHugeFieldNumbers.OptionalGroup._readMessage(
@@ -77652,7 +77652,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to JSON.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestHugeFieldNumbers.OptionalGroup>
@@ -77663,7 +77663,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from JSON.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestHugeFieldNumbers.OptionalGroup {
       return TestHugeFieldNumbers.OptionalGroup._readMessageJSON(
@@ -77673,7 +77673,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Initializes a TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
+     * Initializes TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestHugeFieldNumbers.OptionalGroup {
       return {
@@ -77827,7 +77827,7 @@ export const TestHugeFieldNumbers = {
 
 export const TestExtensionInsideTable = {
   /**
-   * Serializes a TestExtensionInsideTable to protobuf.
+   * Serializes TestExtensionInsideTable to protobuf.
    */
   encode: function (msg: Partial<TestExtensionInsideTable>): Uint8Array {
     return TestExtensionInsideTable._writeMessage(
@@ -77837,7 +77837,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from protobuf.
+   * Deserializes TestExtensionInsideTable from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionInsideTable {
     return TestExtensionInsideTable._readMessage(
@@ -77847,14 +77847,14 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Serializes a TestExtensionInsideTable to JSON.
+   * Serializes TestExtensionInsideTable to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionInsideTable>): string {
     return JSON.stringify(TestExtensionInsideTable._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from JSON.
+   * Deserializes TestExtensionInsideTable from JSON.
    */
   decodeJSON: function (json: string): TestExtensionInsideTable {
     return TestExtensionInsideTable._readMessageJSON(
@@ -77864,7 +77864,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Initializes a TestExtensionInsideTable with all fields set to their default value.
+   * Initializes TestExtensionInsideTable with all fields set to their default value.
    */
   initialize: function (): TestExtensionInsideTable {
     return {
@@ -78058,7 +78058,7 @@ export const TestExtensionInsideTable = {
 
 export const TestExtensionRangeSerialize = {
   /**
-   * Serializes a TestExtensionRangeSerialize to protobuf.
+   * Serializes TestExtensionRangeSerialize to protobuf.
    */
   encode: function (msg: Partial<TestExtensionRangeSerialize>): Uint8Array {
     return TestExtensionRangeSerialize._writeMessage(
@@ -78068,7 +78068,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from protobuf.
+   * Deserializes TestExtensionRangeSerialize from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionRangeSerialize {
     return TestExtensionRangeSerialize._readMessage(
@@ -78078,14 +78078,14 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Serializes a TestExtensionRangeSerialize to JSON.
+   * Serializes TestExtensionRangeSerialize to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionRangeSerialize>): string {
     return JSON.stringify(TestExtensionRangeSerialize._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from JSON.
+   * Deserializes TestExtensionRangeSerialize from JSON.
    */
   decodeJSON: function (json: string): TestExtensionRangeSerialize {
     return TestExtensionRangeSerialize._readMessageJSON(
@@ -78095,7 +78095,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Initializes a TestExtensionRangeSerialize with all fields set to their default value.
+   * Initializes TestExtensionRangeSerialize with all fields set to their default value.
    */
   initialize: function (): TestExtensionRangeSerialize {
     return {
@@ -78485,35 +78485,35 @@ export const MapEnum = {
 
 export const TestMap = {
   /**
-   * Serializes a TestMap to protobuf.
+   * Serializes TestMap to protobuf.
    */
   encode: function (msg: Partial<TestMap>): Uint8Array {
     return TestMap._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestMap from protobuf.
+   * Deserializes TestMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestMap {
     return TestMap._readMessage(TestMap.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a TestMap to JSON.
+   * Serializes TestMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestMap>): string {
     return JSON.stringify(TestMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMap from JSON.
+   * Deserializes TestMap from JSON.
    */
   decodeJSON: function (json: string): TestMap {
     return TestMap._readMessageJSON(TestMap.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestMap with all fields set to their default value.
+   * Initializes TestMap with all fields set to their default value.
    */
   initialize: function (): TestMap {
     return {
@@ -80846,7 +80846,7 @@ export const TestMap = {
 
 export const TestMapSubmessage = {
   /**
-   * Serializes a TestMapSubmessage to protobuf.
+   * Serializes TestMapSubmessage to protobuf.
    */
   encode: function (msg: Partial<TestMapSubmessage>): Uint8Array {
     return TestMapSubmessage._writeMessage(
@@ -80856,7 +80856,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Deserializes a TestMapSubmessage from protobuf.
+   * Deserializes TestMapSubmessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestMapSubmessage {
     return TestMapSubmessage._readMessage(
@@ -80866,14 +80866,14 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Serializes a TestMapSubmessage to JSON.
+   * Serializes TestMapSubmessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestMapSubmessage>): string {
     return JSON.stringify(TestMapSubmessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMapSubmessage from JSON.
+   * Deserializes TestMapSubmessage from JSON.
    */
   decodeJSON: function (json: string): TestMapSubmessage {
     return TestMapSubmessage._readMessageJSON(
@@ -80883,7 +80883,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Initializes a TestMapSubmessage with all fields set to their default value.
+   * Initializes TestMapSubmessage with all fields set to their default value.
    */
   initialize: function (): TestMapSubmessage {
     return {
@@ -80962,7 +80962,7 @@ export const TestMapSubmessage = {
 
 export const TestMessageMap = {
   /**
-   * Serializes a TestMessageMap to protobuf.
+   * Serializes TestMessageMap to protobuf.
    */
   encode: function (msg: Partial<TestMessageMap>): Uint8Array {
     return TestMessageMap._writeMessage(
@@ -80972,7 +80972,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Deserializes a TestMessageMap from protobuf.
+   * Deserializes TestMessageMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestMessageMap {
     return TestMessageMap._readMessage(
@@ -80982,14 +80982,14 @@ export const TestMessageMap = {
   },
 
   /**
-   * Serializes a TestMessageMap to JSON.
+   * Serializes TestMessageMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestMessageMap>): string {
     return JSON.stringify(TestMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageMap from JSON.
+   * Deserializes TestMessageMap from JSON.
    */
   decodeJSON: function (json: string): TestMessageMap {
     return TestMessageMap._readMessageJSON(
@@ -80999,7 +80999,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Initializes a TestMessageMap with all fields set to their default value.
+   * Initializes TestMessageMap with all fields set to their default value.
    */
   initialize: function (): TestMessageMap {
     return {
@@ -81183,7 +81183,7 @@ export const TestMessageMap = {
 
 export const TestSameTypeMap = {
   /**
-   * Serializes a TestSameTypeMap to protobuf.
+   * Serializes TestSameTypeMap to protobuf.
    */
   encode: function (msg: Partial<TestSameTypeMap>): Uint8Array {
     return TestSameTypeMap._writeMessage(
@@ -81193,7 +81193,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Deserializes a TestSameTypeMap from protobuf.
+   * Deserializes TestSameTypeMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestSameTypeMap {
     return TestSameTypeMap._readMessage(
@@ -81203,14 +81203,14 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Serializes a TestSameTypeMap to JSON.
+   * Serializes TestSameTypeMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestSameTypeMap>): string {
     return JSON.stringify(TestSameTypeMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestSameTypeMap from JSON.
+   * Deserializes TestSameTypeMap from JSON.
    */
   decodeJSON: function (json: string): TestSameTypeMap {
     return TestSameTypeMap._readMessageJSON(
@@ -81220,7 +81220,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Initializes a TestSameTypeMap with all fields set to their default value.
+   * Initializes TestSameTypeMap with all fields set to their default value.
    */
   initialize: function (): TestSameTypeMap {
     return {
@@ -81511,7 +81511,7 @@ export const TestSameTypeMap = {
 
 export const TestRequiredMessageMap = {
   /**
-   * Serializes a TestRequiredMessageMap to protobuf.
+   * Serializes TestRequiredMessageMap to protobuf.
    */
   encode: function (msg: Partial<TestRequiredMessageMap>): Uint8Array {
     return TestRequiredMessageMap._writeMessage(
@@ -81521,7 +81521,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from protobuf.
+   * Deserializes TestRequiredMessageMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredMessageMap {
     return TestRequiredMessageMap._readMessage(
@@ -81531,14 +81531,14 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Serializes a TestRequiredMessageMap to JSON.
+   * Serializes TestRequiredMessageMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredMessageMap>): string {
     return JSON.stringify(TestRequiredMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from JSON.
+   * Deserializes TestRequiredMessageMap from JSON.
    */
   decodeJSON: function (json: string): TestRequiredMessageMap {
     return TestRequiredMessageMap._readMessageJSON(
@@ -81548,7 +81548,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Initializes a TestRequiredMessageMap with all fields set to their default value.
+   * Initializes TestRequiredMessageMap with all fields set to their default value.
    */
   initialize: function (): TestRequiredMessageMap {
     return {
@@ -81734,7 +81734,7 @@ export const TestRequiredMessageMap = {
 
 export const TestArenaMap = {
   /**
-   * Serializes a TestArenaMap to protobuf.
+   * Serializes TestArenaMap to protobuf.
    */
   encode: function (msg: Partial<TestArenaMap>): Uint8Array {
     return TestArenaMap._writeMessage(
@@ -81744,7 +81744,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Deserializes a TestArenaMap from protobuf.
+   * Deserializes TestArenaMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestArenaMap {
     return TestArenaMap._readMessage(
@@ -81754,14 +81754,14 @@ export const TestArenaMap = {
   },
 
   /**
-   * Serializes a TestArenaMap to JSON.
+   * Serializes TestArenaMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestArenaMap>): string {
     return JSON.stringify(TestArenaMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestArenaMap from JSON.
+   * Deserializes TestArenaMap from JSON.
    */
   decodeJSON: function (json: string): TestArenaMap {
     return TestArenaMap._readMessageJSON(
@@ -81771,7 +81771,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Initializes a TestArenaMap with all fields set to their default value.
+   * Initializes TestArenaMap with all fields set to their default value.
    */
   initialize: function (): TestArenaMap {
     return {
@@ -83878,7 +83878,7 @@ export const TestArenaMap = {
 
 export const MessageContainingMapCalledEntry = {
   /**
-   * Serializes a MessageContainingMapCalledEntry to protobuf.
+   * Serializes MessageContainingMapCalledEntry to protobuf.
    */
   encode: function (msg: Partial<MessageContainingMapCalledEntry>): Uint8Array {
     return MessageContainingMapCalledEntry._writeMessage(
@@ -83888,7 +83888,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from protobuf.
+   * Deserializes MessageContainingMapCalledEntry from protobuf.
    */
   decode: function (bytes: ByteSource): MessageContainingMapCalledEntry {
     return MessageContainingMapCalledEntry._readMessage(
@@ -83898,7 +83898,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Serializes a MessageContainingMapCalledEntry to JSON.
+   * Serializes MessageContainingMapCalledEntry to JSON.
    */
   encodeJSON: function (msg: Partial<MessageContainingMapCalledEntry>): string {
     return JSON.stringify(
@@ -83907,7 +83907,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from JSON.
+   * Deserializes MessageContainingMapCalledEntry from JSON.
    */
   decodeJSON: function (json: string): MessageContainingMapCalledEntry {
     return MessageContainingMapCalledEntry._readMessageJSON(
@@ -83917,7 +83917,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Initializes a MessageContainingMapCalledEntry with all fields set to their default value.
+   * Initializes MessageContainingMapCalledEntry with all fields set to their default value.
    */
   initialize: function (): MessageContainingMapCalledEntry {
     return {
@@ -84095,7 +84095,7 @@ export const MessageContainingMapCalledEntry = {
 
 export const TestRecursiveMapMessage = {
   /**
-   * Serializes a TestRecursiveMapMessage to protobuf.
+   * Serializes TestRecursiveMapMessage to protobuf.
    */
   encode: function (msg: Partial<TestRecursiveMapMessage>): Uint8Array {
     return TestRecursiveMapMessage._writeMessage(
@@ -84105,7 +84105,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from protobuf.
+   * Deserializes TestRecursiveMapMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRecursiveMapMessage {
     return TestRecursiveMapMessage._readMessage(
@@ -84115,14 +84115,14 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMapMessage to JSON.
+   * Serializes TestRecursiveMapMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRecursiveMapMessage>): string {
     return JSON.stringify(TestRecursiveMapMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from JSON.
+   * Deserializes TestRecursiveMapMessage from JSON.
    */
   decodeJSON: function (json: string): TestRecursiveMapMessage {
     return TestRecursiveMapMessage._readMessageJSON(
@@ -84132,7 +84132,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMapMessage with all fields set to their default value.
+   * Initializes TestRecursiveMapMessage with all fields set to their default value.
    */
   initialize: function (): TestRecursiveMapMessage {
     return {
@@ -84477,35 +84477,35 @@ export interface Any {
 
 export const Any = {
   /**
-   * Serializes a Any to protobuf.
+   * Serializes Any to protobuf.
    */
   encode: function (msg: Partial<Any>): Uint8Array {
     return Any._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Any from protobuf.
+   * Deserializes Any from protobuf.
    */
   decode: function (bytes: ByteSource): Any {
     return Any._readMessage(Any.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Any to JSON.
+   * Serializes Any to JSON.
    */
   encodeJSON: function (msg: Partial<Any>): string {
     return JSON.stringify(Any._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Any from JSON.
+   * Deserializes Any from JSON.
    */
   decodeJSON: function (json: string): Any {
     return Any._readMessageJSON(Any.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Any with all fields set to their default value.
+   * Initializes Any with all fields set to their default value.
    */
   initialize: function (): Any {
     return {
@@ -84628,7 +84628,7 @@ export interface SourceContext {
 
 export const SourceContext = {
   /**
-   * Serializes a SourceContext to protobuf.
+   * Serializes SourceContext to protobuf.
    */
   encode: function (msg: Partial<SourceContext>): Uint8Array {
     return SourceContext._writeMessage(
@@ -84638,7 +84638,7 @@ export const SourceContext = {
   },
 
   /**
-   * Deserializes a SourceContext from protobuf.
+   * Deserializes SourceContext from protobuf.
    */
   decode: function (bytes: ByteSource): SourceContext {
     return SourceContext._readMessage(
@@ -84648,14 +84648,14 @@ export const SourceContext = {
   },
 
   /**
-   * Serializes a SourceContext to JSON.
+   * Serializes SourceContext to JSON.
    */
   encodeJSON: function (msg: Partial<SourceContext>): string {
     return JSON.stringify(SourceContext._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SourceContext from JSON.
+   * Deserializes SourceContext from JSON.
    */
   decodeJSON: function (json: string): SourceContext {
     return SourceContext._readMessageJSON(
@@ -84665,7 +84665,7 @@ export const SourceContext = {
   },
 
   /**
-   * Initializes a SourceContext with all fields set to their default value.
+   * Initializes SourceContext with all fields set to their default value.
    */
   initialize: function (): SourceContext {
     return {
@@ -84997,35 +84997,35 @@ export const Syntax = {
 
 export const Type = {
   /**
-   * Serializes a Type to protobuf.
+   * Serializes Type to protobuf.
    */
   encode: function (msg: Partial<Type>): Uint8Array {
     return Type._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Type from protobuf.
+   * Deserializes Type from protobuf.
    */
   decode: function (bytes: ByteSource): Type {
     return Type._readMessage(Type.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Type to JSON.
+   * Serializes Type to JSON.
    */
   encodeJSON: function (msg: Partial<Type>): string {
     return JSON.stringify(Type._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Type from JSON.
+   * Deserializes Type from JSON.
    */
   decodeJSON: function (json: string): Type {
     return Type._readMessageJSON(Type.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Type with all fields set to their default value.
+   * Initializes Type with all fields set to their default value.
    */
   initialize: function (): Type {
     return {
@@ -85183,35 +85183,35 @@ export const Type = {
 
 export const Field = {
   /**
-   * Serializes a Field to protobuf.
+   * Serializes Field to protobuf.
    */
   encode: function (msg: Partial<Field>): Uint8Array {
     return Field._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Field from protobuf.
+   * Deserializes Field from protobuf.
    */
   decode: function (bytes: ByteSource): Field {
     return Field._readMessage(Field.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Field to JSON.
+   * Serializes Field to JSON.
    */
   encodeJSON: function (msg: Partial<Field>): string {
     return JSON.stringify(Field._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Field from JSON.
+   * Deserializes Field from JSON.
    */
   decodeJSON: function (json: string): Field {
     return Field._readMessageJSON(Field.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Field with all fields set to their default value.
+   * Initializes Field with all fields set to their default value.
    */
   initialize: function (): Field {
     return {
@@ -85698,35 +85698,35 @@ export const Field = {
 
 export const Enum = {
   /**
-   * Serializes a Enum to protobuf.
+   * Serializes Enum to protobuf.
    */
   encode: function (msg: Partial<Enum>): Uint8Array {
     return Enum._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Enum from protobuf.
+   * Deserializes Enum from protobuf.
    */
   decode: function (bytes: ByteSource): Enum {
     return Enum._readMessage(Enum.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Enum to JSON.
+   * Serializes Enum to JSON.
    */
   encodeJSON: function (msg: Partial<Enum>): string {
     return JSON.stringify(Enum._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Enum from JSON.
+   * Deserializes Enum from JSON.
    */
   decodeJSON: function (json: string): Enum {
     return Enum._readMessageJSON(Enum.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Enum with all fields set to their default value.
+   * Initializes Enum with all fields set to their default value.
    */
   initialize: function (): Enum {
     return {
@@ -85873,14 +85873,14 @@ export const Enum = {
 
 export const EnumValue = {
   /**
-   * Serializes a EnumValue to protobuf.
+   * Serializes EnumValue to protobuf.
    */
   encode: function (msg: Partial<EnumValue>): Uint8Array {
     return EnumValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a EnumValue from protobuf.
+   * Deserializes EnumValue from protobuf.
    */
   decode: function (bytes: ByteSource): EnumValue {
     return EnumValue._readMessage(
@@ -85890,21 +85890,21 @@ export const EnumValue = {
   },
 
   /**
-   * Serializes a EnumValue to JSON.
+   * Serializes EnumValue to JSON.
    */
   encodeJSON: function (msg: Partial<EnumValue>): string {
     return JSON.stringify(EnumValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a EnumValue from JSON.
+   * Deserializes EnumValue from JSON.
    */
   decodeJSON: function (json: string): EnumValue {
     return EnumValue._readMessageJSON(EnumValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a EnumValue with all fields set to their default value.
+   * Initializes EnumValue with all fields set to their default value.
    */
   initialize: function (): EnumValue {
     return {
@@ -86008,35 +86008,35 @@ export const EnumValue = {
 
 export const Option = {
   /**
-   * Serializes a Option to protobuf.
+   * Serializes Option to protobuf.
    */
   encode: function (msg: Partial<Option>): Uint8Array {
     return Option._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Option from protobuf.
+   * Deserializes Option from protobuf.
    */
   decode: function (bytes: ByteSource): Option {
     return Option._readMessage(Option.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Option to JSON.
+   * Serializes Option to JSON.
    */
   encodeJSON: function (msg: Partial<Option>): string {
     return JSON.stringify(Option._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Option from JSON.
+   * Deserializes Option from JSON.
    */
   decodeJSON: function (json: string): Option {
     return Option._readMessageJSON(Option.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Option with all fields set to their default value.
+   * Initializes Option with all fields set to their default value.
    */
   initialize: function (): Option {
     return {
@@ -86345,35 +86345,35 @@ export interface Mixin {
 
 export const Api = {
   /**
-   * Serializes a Api to protobuf.
+   * Serializes Api to protobuf.
    */
   encode: function (msg: Partial<Api>): Uint8Array {
     return Api._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Api from protobuf.
+   * Deserializes Api from protobuf.
    */
   decode: function (bytes: ByteSource): Api {
     return Api._readMessage(Api.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Api to JSON.
+   * Serializes Api to JSON.
    */
   encodeJSON: function (msg: Partial<Api>): string {
     return JSON.stringify(Api._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Api from JSON.
+   * Deserializes Api from JSON.
    */
   decodeJSON: function (json: string): Api {
     return Api._readMessageJSON(Api.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Api with all fields set to their default value.
+   * Initializes Api with all fields set to their default value.
    */
   initialize: function (): Api {
     return {
@@ -86552,35 +86552,35 @@ export const Api = {
 
 export const Method = {
   /**
-   * Serializes a Method to protobuf.
+   * Serializes Method to protobuf.
    */
   encode: function (msg: Partial<Method>): Uint8Array {
     return Method._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Method from protobuf.
+   * Deserializes Method from protobuf.
    */
   decode: function (bytes: ByteSource): Method {
     return Method._readMessage(Method.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Method to JSON.
+   * Serializes Method to JSON.
    */
   encodeJSON: function (msg: Partial<Method>): string {
     return JSON.stringify(Method._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Method from JSON.
+   * Deserializes Method from JSON.
    */
   decodeJSON: function (json: string): Method {
     return Method._readMessageJSON(Method.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Method with all fields set to their default value.
+   * Initializes Method with all fields set to their default value.
    */
   initialize: function (): Method {
     return {
@@ -86743,35 +86743,35 @@ export const Method = {
 
 export const Mixin = {
   /**
-   * Serializes a Mixin to protobuf.
+   * Serializes Mixin to protobuf.
    */
   encode: function (msg: Partial<Mixin>): Uint8Array {
     return Mixin._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Mixin from protobuf.
+   * Deserializes Mixin from protobuf.
    */
   decode: function (bytes: ByteSource): Mixin {
     return Mixin._readMessage(Mixin.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Mixin to JSON.
+   * Serializes Mixin to JSON.
    */
   encodeJSON: function (msg: Partial<Mixin>): string {
     return JSON.stringify(Mixin._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Mixin from JSON.
+   * Deserializes Mixin from JSON.
    */
   decodeJSON: function (json: string): Mixin {
     return Mixin._readMessageJSON(Mixin.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Mixin with all fields set to their default value.
+   * Initializes Mixin with all fields set to their default value.
    */
   initialize: function (): Mixin {
     return {
@@ -86962,14 +86962,14 @@ export interface Duration {
 
 export const Duration = {
   /**
-   * Serializes a Duration to protobuf.
+   * Serializes Duration to protobuf.
    */
   encode: function (msg: Partial<Duration>): Uint8Array {
     return Duration._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Duration from protobuf.
+   * Deserializes Duration from protobuf.
    */
   decode: function (bytes: ByteSource): Duration {
     return Duration._readMessage(
@@ -86979,21 +86979,21 @@ export const Duration = {
   },
 
   /**
-   * Serializes a Duration to JSON.
+   * Serializes Duration to JSON.
    */
   encodeJSON: function (msg: Partial<Duration>): string {
     return JSON.stringify(Duration._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Duration from JSON.
+   * Deserializes Duration from JSON.
    */
   decodeJSON: function (json: string): Duration {
     return Duration._readMessageJSON(Duration.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Duration with all fields set to their default value.
+   * Initializes Duration with all fields set to their default value.
    */
   initialize: function (): Duration {
     return {
@@ -87119,35 +87119,35 @@ export interface Empty {}
 
 export const Empty = {
   /**
-   * Serializes a Empty to protobuf.
+   * Serializes Empty to protobuf.
    */
   encode: function (_msg?: Partial<Empty>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a Empty from protobuf.
+   * Deserializes Empty from protobuf.
    */
   decode: function (_bytes?: ByteSource): Empty {
     return {};
   },
 
   /**
-   * Serializes a Empty to JSON.
+   * Serializes Empty to JSON.
    */
   encodeJSON: function (_msg?: Partial<Empty>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a Empty from JSON.
+   * Deserializes Empty from JSON.
    */
   decodeJSON: function (_json?: string): Empty {
     return {};
   },
 
   /**
-   * Initializes a Empty with all fields set to their default value.
+   * Initializes Empty with all fields set to their default value.
    */
   initialize: function (): Empty {
     return {};
@@ -87425,14 +87425,14 @@ export interface FieldMask {
 
 export const FieldMask = {
   /**
-   * Serializes a FieldMask to protobuf.
+   * Serializes FieldMask to protobuf.
    */
   encode: function (msg: Partial<FieldMask>): Uint8Array {
     return FieldMask._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FieldMask from protobuf.
+   * Deserializes FieldMask from protobuf.
    */
   decode: function (bytes: ByteSource): FieldMask {
     return FieldMask._readMessage(
@@ -87442,21 +87442,21 @@ export const FieldMask = {
   },
 
   /**
-   * Serializes a FieldMask to JSON.
+   * Serializes FieldMask to JSON.
    */
   encodeJSON: function (msg: Partial<FieldMask>): string {
     return JSON.stringify(FieldMask._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FieldMask from JSON.
+   * Deserializes FieldMask from JSON.
    */
   decodeJSON: function (json: string): FieldMask {
     return FieldMask._readMessageJSON(FieldMask.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a FieldMask with all fields set to their default value.
+   * Initializes FieldMask with all fields set to their default value.
    */
   initialize: function (): FieldMask {
     return {
@@ -87665,35 +87665,35 @@ export const NullValue = {
 
 export const Struct = {
   /**
-   * Serializes a Struct to protobuf.
+   * Serializes Struct to protobuf.
    */
   encode: function (msg: Partial<Struct>): Uint8Array {
     return Struct._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Struct from protobuf.
+   * Deserializes Struct from protobuf.
    */
   decode: function (bytes: ByteSource): Struct {
     return Struct._readMessage(Struct.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Struct to JSON.
+   * Serializes Struct to JSON.
    */
   encodeJSON: function (msg: Partial<Struct>): string {
     return JSON.stringify(Struct._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Struct from JSON.
+   * Deserializes Struct from JSON.
    */
   decodeJSON: function (json: string): Struct {
     return Struct._readMessageJSON(Struct.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Struct with all fields set to their default value.
+   * Initializes Struct with all fields set to their default value.
    */
   initialize: function (): Struct {
     return {
@@ -87865,35 +87865,35 @@ export const Struct = {
 
 export const Value = {
   /**
-   * Serializes a Value to protobuf.
+   * Serializes Value to protobuf.
    */
   encode: function (msg: Partial<Value>): Uint8Array {
     return Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Value from protobuf.
+   * Deserializes Value from protobuf.
    */
   decode: function (bytes: ByteSource): Value {
     return Value._readMessage(Value.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Value to JSON.
+   * Serializes Value to JSON.
    */
   encodeJSON: function (msg: Partial<Value>): string {
     return JSON.stringify(Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Value from JSON.
+   * Deserializes Value from JSON.
    */
   decodeJSON: function (json: string): Value {
     return Value._readMessageJSON(Value.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Value with all fields set to their default value.
+   * Initializes Value with all fields set to their default value.
    */
   initialize: function (): Value {
     return {
@@ -88040,14 +88040,14 @@ export const Value = {
 
 export const ListValue = {
   /**
-   * Serializes a ListValue to protobuf.
+   * Serializes ListValue to protobuf.
    */
   encode: function (msg: Partial<ListValue>): Uint8Array {
     return ListValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a ListValue from protobuf.
+   * Deserializes ListValue from protobuf.
    */
   decode: function (bytes: ByteSource): ListValue {
     return ListValue._readMessage(
@@ -88057,21 +88057,21 @@ export const ListValue = {
   },
 
   /**
-   * Serializes a ListValue to JSON.
+   * Serializes ListValue to JSON.
    */
   encodeJSON: function (msg: Partial<ListValue>): string {
     return JSON.stringify(ListValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ListValue from JSON.
+   * Deserializes ListValue from JSON.
    */
   decodeJSON: function (json: string): ListValue {
     return ListValue._readMessageJSON(ListValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a ListValue with all fields set to their default value.
+   * Initializes ListValue with all fields set to their default value.
    */
   initialize: function (): ListValue {
     return {
@@ -88286,14 +88286,14 @@ export interface Timestamp {
 
 export const Timestamp = {
   /**
-   * Serializes a Timestamp to protobuf.
+   * Serializes Timestamp to protobuf.
    */
   encode: function (msg: Partial<Timestamp>): Uint8Array {
     return Timestamp._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Timestamp from protobuf.
+   * Deserializes Timestamp from protobuf.
    */
   decode: function (bytes: ByteSource): Timestamp {
     return Timestamp._readMessage(
@@ -88303,21 +88303,21 @@ export const Timestamp = {
   },
 
   /**
-   * Serializes a Timestamp to JSON.
+   * Serializes Timestamp to JSON.
    */
   encodeJSON: function (msg: Partial<Timestamp>): string {
     return JSON.stringify(Timestamp._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Timestamp from JSON.
+   * Deserializes Timestamp from JSON.
    */
   decodeJSON: function (json: string): Timestamp {
     return Timestamp._readMessageJSON(Timestamp.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Timestamp with all fields set to their default value.
+   * Initializes Timestamp with all fields set to their default value.
    */
   initialize: function (): Timestamp {
     return {
@@ -88543,14 +88543,14 @@ export interface BytesValue {
 
 export const DoubleValue = {
   /**
-   * Serializes a DoubleValue to protobuf.
+   * Serializes DoubleValue to protobuf.
    */
   encode: function (msg: Partial<DoubleValue>): Uint8Array {
     return DoubleValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a DoubleValue from protobuf.
+   * Deserializes DoubleValue from protobuf.
    */
   decode: function (bytes: ByteSource): DoubleValue {
     return DoubleValue._readMessage(
@@ -88560,14 +88560,14 @@ export const DoubleValue = {
   },
 
   /**
-   * Serializes a DoubleValue to JSON.
+   * Serializes DoubleValue to JSON.
    */
   encodeJSON: function (msg: Partial<DoubleValue>): string {
     return JSON.stringify(DoubleValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a DoubleValue from JSON.
+   * Deserializes DoubleValue from JSON.
    */
   decodeJSON: function (json: string): DoubleValue {
     return DoubleValue._readMessageJSON(
@@ -88577,7 +88577,7 @@ export const DoubleValue = {
   },
 
   /**
-   * Initializes a DoubleValue with all fields set to their default value.
+   * Initializes DoubleValue with all fields set to their default value.
    */
   initialize: function (): DoubleValue {
     return {
@@ -88645,14 +88645,14 @@ export const DoubleValue = {
 
 export const FloatValue = {
   /**
-   * Serializes a FloatValue to protobuf.
+   * Serializes FloatValue to protobuf.
    */
   encode: function (msg: Partial<FloatValue>): Uint8Array {
     return FloatValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FloatValue from protobuf.
+   * Deserializes FloatValue from protobuf.
    */
   decode: function (bytes: ByteSource): FloatValue {
     return FloatValue._readMessage(
@@ -88662,14 +88662,14 @@ export const FloatValue = {
   },
 
   /**
-   * Serializes a FloatValue to JSON.
+   * Serializes FloatValue to JSON.
    */
   encodeJSON: function (msg: Partial<FloatValue>): string {
     return JSON.stringify(FloatValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FloatValue from JSON.
+   * Deserializes FloatValue from JSON.
    */
   decodeJSON: function (json: string): FloatValue {
     return FloatValue._readMessageJSON(
@@ -88679,7 +88679,7 @@ export const FloatValue = {
   },
 
   /**
-   * Initializes a FloatValue with all fields set to their default value.
+   * Initializes FloatValue with all fields set to their default value.
    */
   initialize: function (): FloatValue {
     return {
@@ -88747,14 +88747,14 @@ export const FloatValue = {
 
 export const Int64Value = {
   /**
-   * Serializes a Int64Value to protobuf.
+   * Serializes Int64Value to protobuf.
    */
   encode: function (msg: Partial<Int64Value>): Uint8Array {
     return Int64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int64Value from protobuf.
+   * Deserializes Int64Value from protobuf.
    */
   decode: function (bytes: ByteSource): Int64Value {
     return Int64Value._readMessage(
@@ -88764,14 +88764,14 @@ export const Int64Value = {
   },
 
   /**
-   * Serializes a Int64Value to JSON.
+   * Serializes Int64Value to JSON.
    */
   encodeJSON: function (msg: Partial<Int64Value>): string {
     return JSON.stringify(Int64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Value from JSON.
+   * Deserializes Int64Value from JSON.
    */
   decodeJSON: function (json: string): Int64Value {
     return Int64Value._readMessageJSON(
@@ -88781,7 +88781,7 @@ export const Int64Value = {
   },
 
   /**
-   * Initializes a Int64Value with all fields set to their default value.
+   * Initializes Int64Value with all fields set to their default value.
    */
   initialize: function (): Int64Value {
     return {
@@ -88849,14 +88849,14 @@ export const Int64Value = {
 
 export const UInt64Value = {
   /**
-   * Serializes a UInt64Value to protobuf.
+   * Serializes UInt64Value to protobuf.
    */
   encode: function (msg: Partial<UInt64Value>): Uint8Array {
     return UInt64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt64Value from protobuf.
+   * Deserializes UInt64Value from protobuf.
    */
   decode: function (bytes: ByteSource): UInt64Value {
     return UInt64Value._readMessage(
@@ -88866,14 +88866,14 @@ export const UInt64Value = {
   },
 
   /**
-   * Serializes a UInt64Value to JSON.
+   * Serializes UInt64Value to JSON.
    */
   encodeJSON: function (msg: Partial<UInt64Value>): string {
     return JSON.stringify(UInt64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt64Value from JSON.
+   * Deserializes UInt64Value from JSON.
    */
   decodeJSON: function (json: string): UInt64Value {
     return UInt64Value._readMessageJSON(
@@ -88883,7 +88883,7 @@ export const UInt64Value = {
   },
 
   /**
-   * Initializes a UInt64Value with all fields set to their default value.
+   * Initializes UInt64Value with all fields set to their default value.
    */
   initialize: function (): UInt64Value {
     return {
@@ -88951,14 +88951,14 @@ export const UInt64Value = {
 
 export const Int32Value = {
   /**
-   * Serializes a Int32Value to protobuf.
+   * Serializes Int32Value to protobuf.
    */
   encode: function (msg: Partial<Int32Value>): Uint8Array {
     return Int32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int32Value from protobuf.
+   * Deserializes Int32Value from protobuf.
    */
   decode: function (bytes: ByteSource): Int32Value {
     return Int32Value._readMessage(
@@ -88968,14 +88968,14 @@ export const Int32Value = {
   },
 
   /**
-   * Serializes a Int32Value to JSON.
+   * Serializes Int32Value to JSON.
    */
   encodeJSON: function (msg: Partial<Int32Value>): string {
     return JSON.stringify(Int32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Value from JSON.
+   * Deserializes Int32Value from JSON.
    */
   decodeJSON: function (json: string): Int32Value {
     return Int32Value._readMessageJSON(
@@ -88985,7 +88985,7 @@ export const Int32Value = {
   },
 
   /**
-   * Initializes a Int32Value with all fields set to their default value.
+   * Initializes Int32Value with all fields set to their default value.
    */
   initialize: function (): Int32Value {
     return {
@@ -89053,14 +89053,14 @@ export const Int32Value = {
 
 export const UInt32Value = {
   /**
-   * Serializes a UInt32Value to protobuf.
+   * Serializes UInt32Value to protobuf.
    */
   encode: function (msg: Partial<UInt32Value>): Uint8Array {
     return UInt32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt32Value from protobuf.
+   * Deserializes UInt32Value from protobuf.
    */
   decode: function (bytes: ByteSource): UInt32Value {
     return UInt32Value._readMessage(
@@ -89070,14 +89070,14 @@ export const UInt32Value = {
   },
 
   /**
-   * Serializes a UInt32Value to JSON.
+   * Serializes UInt32Value to JSON.
    */
   encodeJSON: function (msg: Partial<UInt32Value>): string {
     return JSON.stringify(UInt32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt32Value from JSON.
+   * Deserializes UInt32Value from JSON.
    */
   decodeJSON: function (json: string): UInt32Value {
     return UInt32Value._readMessageJSON(
@@ -89087,7 +89087,7 @@ export const UInt32Value = {
   },
 
   /**
-   * Initializes a UInt32Value with all fields set to their default value.
+   * Initializes UInt32Value with all fields set to their default value.
    */
   initialize: function (): UInt32Value {
     return {
@@ -89155,14 +89155,14 @@ export const UInt32Value = {
 
 export const BoolValue = {
   /**
-   * Serializes a BoolValue to protobuf.
+   * Serializes BoolValue to protobuf.
    */
   encode: function (msg: Partial<BoolValue>): Uint8Array {
     return BoolValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolValue from protobuf.
+   * Deserializes BoolValue from protobuf.
    */
   decode: function (bytes: ByteSource): BoolValue {
     return BoolValue._readMessage(
@@ -89172,21 +89172,21 @@ export const BoolValue = {
   },
 
   /**
-   * Serializes a BoolValue to JSON.
+   * Serializes BoolValue to JSON.
    */
   encodeJSON: function (msg: Partial<BoolValue>): string {
     return JSON.stringify(BoolValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolValue from JSON.
+   * Deserializes BoolValue from JSON.
    */
   decodeJSON: function (json: string): BoolValue {
     return BoolValue._readMessageJSON(BoolValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a BoolValue with all fields set to their default value.
+   * Initializes BoolValue with all fields set to their default value.
    */
   initialize: function (): BoolValue {
     return {
@@ -89254,14 +89254,14 @@ export const BoolValue = {
 
 export const StringValue = {
   /**
-   * Serializes a StringValue to protobuf.
+   * Serializes StringValue to protobuf.
    */
   encode: function (msg: Partial<StringValue>): Uint8Array {
     return StringValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a StringValue from protobuf.
+   * Deserializes StringValue from protobuf.
    */
   decode: function (bytes: ByteSource): StringValue {
     return StringValue._readMessage(
@@ -89271,14 +89271,14 @@ export const StringValue = {
   },
 
   /**
-   * Serializes a StringValue to JSON.
+   * Serializes StringValue to JSON.
    */
   encodeJSON: function (msg: Partial<StringValue>): string {
     return JSON.stringify(StringValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a StringValue from JSON.
+   * Deserializes StringValue from JSON.
    */
   decodeJSON: function (json: string): StringValue {
     return StringValue._readMessageJSON(
@@ -89288,7 +89288,7 @@ export const StringValue = {
   },
 
   /**
-   * Initializes a StringValue with all fields set to their default value.
+   * Initializes StringValue with all fields set to their default value.
    */
   initialize: function (): StringValue {
     return {
@@ -89356,14 +89356,14 @@ export const StringValue = {
 
 export const BytesValue = {
   /**
-   * Serializes a BytesValue to protobuf.
+   * Serializes BytesValue to protobuf.
    */
   encode: function (msg: Partial<BytesValue>): Uint8Array {
     return BytesValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BytesValue from protobuf.
+   * Deserializes BytesValue from protobuf.
    */
   decode: function (bytes: ByteSource): BytesValue {
     return BytesValue._readMessage(
@@ -89373,14 +89373,14 @@ export const BytesValue = {
   },
 
   /**
-   * Serializes a BytesValue to JSON.
+   * Serializes BytesValue to JSON.
    */
   encodeJSON: function (msg: Partial<BytesValue>): string {
     return JSON.stringify(BytesValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BytesValue from JSON.
+   * Deserializes BytesValue from JSON.
    */
   decodeJSON: function (json: string): BytesValue {
     return BytesValue._readMessageJSON(
@@ -89390,7 +89390,7 @@ export const BytesValue = {
   },
 
   /**
-   * Initializes a BytesValue with all fields set to their default value.
+   * Initializes BytesValue with all fields set to their default value.
    */
   initialize: function (): BytesValue {
     return {
@@ -89651,7 +89651,7 @@ declare namespace MapWellKnownTypes {
 
 export const TestWellKnownTypes = {
   /**
-   * Serializes a TestWellKnownTypes to protobuf.
+   * Serializes TestWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<TestWellKnownTypes>): Uint8Array {
     return TestWellKnownTypes._writeMessage(
@@ -89661,7 +89661,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from protobuf.
+   * Deserializes TestWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestWellKnownTypes {
     return TestWellKnownTypes._readMessage(
@@ -89671,14 +89671,14 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Serializes a TestWellKnownTypes to JSON.
+   * Serializes TestWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestWellKnownTypes>): string {
     return JSON.stringify(TestWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from JSON.
+   * Deserializes TestWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): TestWellKnownTypes {
     return TestWellKnownTypes._readMessageJSON(
@@ -89688,7 +89688,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Initializes a TestWellKnownTypes with all fields set to their default value.
+   * Initializes TestWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): TestWellKnownTypes {
     return {
@@ -90137,7 +90137,7 @@ export const TestWellKnownTypes = {
 
 export const RepeatedWellKnownTypes = {
   /**
-   * Serializes a RepeatedWellKnownTypes to protobuf.
+   * Serializes RepeatedWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<RepeatedWellKnownTypes>): Uint8Array {
     return RepeatedWellKnownTypes._writeMessage(
@@ -90147,7 +90147,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from protobuf.
+   * Deserializes RepeatedWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): RepeatedWellKnownTypes {
     return RepeatedWellKnownTypes._readMessage(
@@ -90157,14 +90157,14 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Serializes a RepeatedWellKnownTypes to JSON.
+   * Serializes RepeatedWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<RepeatedWellKnownTypes>): string {
     return JSON.stringify(RepeatedWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from JSON.
+   * Deserializes RepeatedWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): RepeatedWellKnownTypes {
     return RepeatedWellKnownTypes._readMessageJSON(
@@ -90174,7 +90174,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Initializes a RepeatedWellKnownTypes with all fields set to their default value.
+   * Initializes RepeatedWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): RepeatedWellKnownTypes {
     return {
@@ -90674,7 +90674,7 @@ export const RepeatedWellKnownTypes = {
 
 export const OneofWellKnownTypes = {
   /**
-   * Serializes a OneofWellKnownTypes to protobuf.
+   * Serializes OneofWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<OneofWellKnownTypes>): Uint8Array {
     return OneofWellKnownTypes._writeMessage(
@@ -90684,7 +90684,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from protobuf.
+   * Deserializes OneofWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): OneofWellKnownTypes {
     return OneofWellKnownTypes._readMessage(
@@ -90694,14 +90694,14 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Serializes a OneofWellKnownTypes to JSON.
+   * Serializes OneofWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<OneofWellKnownTypes>): string {
     return JSON.stringify(OneofWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from JSON.
+   * Deserializes OneofWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): OneofWellKnownTypes {
     return OneofWellKnownTypes._readMessageJSON(
@@ -90711,7 +90711,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Initializes a OneofWellKnownTypes with all fields set to their default value.
+   * Initializes OneofWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): OneofWellKnownTypes {
     return {
@@ -91140,7 +91140,7 @@ export const OneofWellKnownTypes = {
 
 export const MapWellKnownTypes = {
   /**
-   * Serializes a MapWellKnownTypes to protobuf.
+   * Serializes MapWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<MapWellKnownTypes>): Uint8Array {
     return MapWellKnownTypes._writeMessage(
@@ -91150,7 +91150,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from protobuf.
+   * Deserializes MapWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): MapWellKnownTypes {
     return MapWellKnownTypes._readMessage(
@@ -91160,14 +91160,14 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Serializes a MapWellKnownTypes to JSON.
+   * Serializes MapWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<MapWellKnownTypes>): string {
     return JSON.stringify(MapWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from JSON.
+   * Deserializes MapWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): MapWellKnownTypes {
     return MapWellKnownTypes._readMessageJSON(
@@ -91177,7 +91177,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Initializes a MapWellKnownTypes with all fields set to their default value.
+   * Initializes MapWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): MapWellKnownTypes {
     return {
@@ -93754,7 +93754,7 @@ export const ForeignEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg: Partial<TestAllTypes>): Uint8Array {
     return TestAllTypes._writeMessage(
@@ -93764,7 +93764,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestAllTypes {
     return TestAllTypes._readMessage(
@@ -93774,14 +93774,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestAllTypes>): string {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json: string): TestAllTypes {
     return TestAllTypes._readMessageJSON(
@@ -93791,7 +93791,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function (): TestAllTypes {
     return {
@@ -94885,7 +94885,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.NestedMessage>): Uint8Array {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -94895,7 +94895,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessage(
@@ -94905,14 +94905,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.NestedMessage>): string {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -94922,7 +94922,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.NestedMessage {
       return {
@@ -94997,7 +94997,7 @@ export const TestAllTypes = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestPackedTypes>): Uint8Array {
     return TestPackedTypes._writeMessage(
@@ -95007,7 +95007,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestPackedTypes {
     return TestPackedTypes._readMessage(
@@ -95017,14 +95017,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestPackedTypes>): string {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestPackedTypes {
     return TestPackedTypes._readMessageJSON(
@@ -95034,7 +95034,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function (): TestPackedTypes {
     return {
@@ -95318,7 +95318,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestUnpackedTypes>): Uint8Array {
     return TestUnpackedTypes._writeMessage(
@@ -95328,7 +95328,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestUnpackedTypes {
     return TestUnpackedTypes._readMessage(
@@ -95338,14 +95338,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestUnpackedTypes>): string {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestUnpackedTypes {
     return TestUnpackedTypes._readMessageJSON(
@@ -95355,7 +95355,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function (): TestUnpackedTypes {
     return {
@@ -95645,7 +95645,7 @@ export const TestUnpackedTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg: Partial<NestedTestAllTypes>): Uint8Array {
     return NestedTestAllTypes._writeMessage(
@@ -95655,7 +95655,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): NestedTestAllTypes {
     return NestedTestAllTypes._readMessage(
@@ -95665,14 +95665,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<NestedTestAllTypes>): string {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json: string): NestedTestAllTypes {
     return NestedTestAllTypes._readMessageJSON(
@@ -95682,7 +95682,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function (): NestedTestAllTypes {
     return {
@@ -95781,7 +95781,7 @@ export const NestedTestAllTypes = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg: Partial<ForeignMessage>): Uint8Array {
     return ForeignMessage._writeMessage(
@@ -95791,7 +95791,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ForeignMessage {
     return ForeignMessage._readMessage(
@@ -95801,14 +95801,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ForeignMessage>): string {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json: string): ForeignMessage {
     return ForeignMessage._readMessageJSON(
@@ -95818,7 +95818,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function (): ForeignMessage {
     return {
@@ -95889,35 +95889,35 @@ export const ForeignMessage = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestEmptyMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestEmptyMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessage {
     return {};
@@ -95965,7 +95965,7 @@ export const TestEmptyMessage = {
 
 export const TestMessageWithDummy = {
   /**
-   * Serializes a TestMessageWithDummy to protobuf.
+   * Serializes TestMessageWithDummy to protobuf.
    */
   encode: function (msg: Partial<TestMessageWithDummy>): Uint8Array {
     return TestMessageWithDummy._writeMessage(
@@ -95975,7 +95975,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from protobuf.
+   * Deserializes TestMessageWithDummy from protobuf.
    */
   decode: function (bytes: ByteSource): TestMessageWithDummy {
     return TestMessageWithDummy._readMessage(
@@ -95985,14 +95985,14 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Serializes a TestMessageWithDummy to JSON.
+   * Serializes TestMessageWithDummy to JSON.
    */
   encodeJSON: function (msg: Partial<TestMessageWithDummy>): string {
     return JSON.stringify(TestMessageWithDummy._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from JSON.
+   * Deserializes TestMessageWithDummy from JSON.
    */
   decodeJSON: function (json: string): TestMessageWithDummy {
     return TestMessageWithDummy._readMessageJSON(
@@ -96002,7 +96002,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Initializes a TestMessageWithDummy with all fields set to their default value.
+   * Initializes TestMessageWithDummy with all fields set to their default value.
    */
   initialize: function (): TestMessageWithDummy {
     return {
@@ -96076,14 +96076,14 @@ export const TestMessageWithDummy = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg: Partial<TestOneof2>): Uint8Array {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof2 {
     return TestOneof2._readMessage(
@@ -96093,14 +96093,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof2>): string {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json: string): TestOneof2 {
     return TestOneof2._readMessageJSON(
@@ -96110,7 +96110,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function (): TestOneof2 {
     return {};
@@ -96341,7 +96341,7 @@ export interface PublicImportMessage {
 
 export const PublicImportMessage = {
   /**
-   * Serializes a PublicImportMessage to protobuf.
+   * Serializes PublicImportMessage to protobuf.
    */
   encode: function (msg: Partial<PublicImportMessage>): Uint8Array {
     return PublicImportMessage._writeMessage(
@@ -96351,7 +96351,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Deserializes a PublicImportMessage from protobuf.
+   * Deserializes PublicImportMessage from protobuf.
    */
   decode: function (bytes: ByteSource): PublicImportMessage {
     return PublicImportMessage._readMessage(
@@ -96361,14 +96361,14 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Serializes a PublicImportMessage to JSON.
+   * Serializes PublicImportMessage to JSON.
    */
   encodeJSON: function (msg: Partial<PublicImportMessage>): string {
     return JSON.stringify(PublicImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a PublicImportMessage from JSON.
+   * Deserializes PublicImportMessage from JSON.
    */
   decodeJSON: function (json: string): PublicImportMessage {
     return PublicImportMessage._readMessageJSON(
@@ -96378,7 +96378,7 @@ export const PublicImportMessage = {
   },
 
   /**
-   * Initializes a PublicImportMessage with all fields set to their default value.
+   * Initializes PublicImportMessage with all fields set to their default value.
    */
   initialize: function (): PublicImportMessage {
     return {
@@ -96592,7 +96592,7 @@ export const ImportEnumForMap = {
 
 export const ImportMessage = {
   /**
-   * Serializes a ImportMessage to protobuf.
+   * Serializes ImportMessage to protobuf.
    */
   encode: function (msg: Partial<ImportMessage>): Uint8Array {
     return ImportMessage._writeMessage(
@@ -96602,7 +96602,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Deserializes a ImportMessage from protobuf.
+   * Deserializes ImportMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ImportMessage {
     return ImportMessage._readMessage(
@@ -96612,14 +96612,14 @@ export const ImportMessage = {
   },
 
   /**
-   * Serializes a ImportMessage to JSON.
+   * Serializes ImportMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ImportMessage>): string {
     return JSON.stringify(ImportMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ImportMessage from JSON.
+   * Deserializes ImportMessage from JSON.
    */
   decodeJSON: function (json: string): ImportMessage {
     return ImportMessage._readMessageJSON(
@@ -96629,7 +96629,7 @@ export const ImportMessage = {
   },
 
   /**
-   * Initializes a ImportMessage with all fields set to their default value.
+   * Initializes ImportMessage with all fields set to their default value.
    */
   initialize: function (): ImportMessage {
     return {
@@ -98689,7 +98689,7 @@ export const VeryLargeEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg: Partial<TestAllTypes>): Uint8Array {
     return TestAllTypes._writeMessage(
@@ -98699,7 +98699,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestAllTypes {
     return TestAllTypes._readMessage(
@@ -98709,14 +98709,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestAllTypes>): string {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json: string): TestAllTypes {
     return TestAllTypes._readMessageJSON(
@@ -98726,7 +98726,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function (): TestAllTypes {
     return {
@@ -100133,7 +100133,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.NestedMessage>): Uint8Array {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -100143,7 +100143,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessage(
@@ -100153,14 +100153,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.NestedMessage>): string {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -100170,7 +100170,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.NestedMessage {
       return {
@@ -100244,7 +100244,7 @@ export const TestAllTypes = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestAllTypes.OptionalGroup to protobuf.
+     * Serializes TestAllTypes.OptionalGroup to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.OptionalGroup>): Uint8Array {
       return TestAllTypes.OptionalGroup._writeMessage(
@@ -100254,7 +100254,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from protobuf.
+     * Deserializes TestAllTypes.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.OptionalGroup {
       return TestAllTypes.OptionalGroup._readMessage(
@@ -100264,14 +100264,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.OptionalGroup to JSON.
+     * Serializes TestAllTypes.OptionalGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.OptionalGroup>): string {
       return JSON.stringify(TestAllTypes.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.OptionalGroup from JSON.
+     * Deserializes TestAllTypes.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.OptionalGroup {
       return TestAllTypes.OptionalGroup._readMessageJSON(
@@ -100281,7 +100281,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.OptionalGroup with all fields set to their default value.
+     * Initializes TestAllTypes.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.OptionalGroup {
       return {
@@ -100355,7 +100355,7 @@ export const TestAllTypes = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to protobuf.
+     * Serializes TestAllTypes.RepeatedGroup to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.RepeatedGroup>): Uint8Array {
       return TestAllTypes.RepeatedGroup._writeMessage(
@@ -100365,7 +100365,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from protobuf.
+     * Deserializes TestAllTypes.RepeatedGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.RepeatedGroup {
       return TestAllTypes.RepeatedGroup._readMessage(
@@ -100375,14 +100375,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.RepeatedGroup to JSON.
+     * Serializes TestAllTypes.RepeatedGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.RepeatedGroup>): string {
       return JSON.stringify(TestAllTypes.RepeatedGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.RepeatedGroup from JSON.
+     * Deserializes TestAllTypes.RepeatedGroup from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.RepeatedGroup {
       return TestAllTypes.RepeatedGroup._readMessageJSON(
@@ -100392,7 +100392,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.RepeatedGroup with all fields set to their default value.
+     * Initializes TestAllTypes.RepeatedGroup with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.RepeatedGroup {
       return {
@@ -100467,7 +100467,7 @@ export const TestAllTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg: Partial<NestedTestAllTypes>): Uint8Array {
     return NestedTestAllTypes._writeMessage(
@@ -100477,7 +100477,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): NestedTestAllTypes {
     return NestedTestAllTypes._readMessage(
@@ -100487,14 +100487,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<NestedTestAllTypes>): string {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json: string): NestedTestAllTypes {
     return NestedTestAllTypes._readMessageJSON(
@@ -100504,7 +100504,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function (): NestedTestAllTypes {
     return {
@@ -100630,7 +100630,7 @@ export const NestedTestAllTypes = {
 
 export const TestDeprecatedFields = {
   /**
-   * Serializes a TestDeprecatedFields to protobuf.
+   * Serializes TestDeprecatedFields to protobuf.
    */
   encode: function (msg: Partial<TestDeprecatedFields>): Uint8Array {
     return TestDeprecatedFields._writeMessage(
@@ -100640,7 +100640,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from protobuf.
+   * Deserializes TestDeprecatedFields from protobuf.
    */
   decode: function (bytes: ByteSource): TestDeprecatedFields {
     return TestDeprecatedFields._readMessage(
@@ -100650,14 +100650,14 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Serializes a TestDeprecatedFields to JSON.
+   * Serializes TestDeprecatedFields to JSON.
    */
   encodeJSON: function (msg: Partial<TestDeprecatedFields>): string {
     return JSON.stringify(TestDeprecatedFields._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDeprecatedFields from JSON.
+   * Deserializes TestDeprecatedFields from JSON.
    */
   decodeJSON: function (json: string): TestDeprecatedFields {
     return TestDeprecatedFields._readMessageJSON(
@@ -100667,7 +100667,7 @@ export const TestDeprecatedFields = {
   },
 
   /**
-   * Initializes a TestDeprecatedFields with all fields set to their default value.
+   * Initializes TestDeprecatedFields with all fields set to their default value.
    */
   initialize: function (): TestDeprecatedFields {
     return {
@@ -100756,35 +100756,35 @@ export const TestDeprecatedFields = {
 
 export const TestDeprecatedMessage = {
   /**
-   * Serializes a TestDeprecatedMessage to protobuf.
+   * Serializes TestDeprecatedMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestDeprecatedMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from protobuf.
+   * Deserializes TestDeprecatedMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestDeprecatedMessage {
     return {};
   },
 
   /**
-   * Serializes a TestDeprecatedMessage to JSON.
+   * Serializes TestDeprecatedMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestDeprecatedMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestDeprecatedMessage from JSON.
+   * Deserializes TestDeprecatedMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestDeprecatedMessage {
     return {};
   },
 
   /**
-   * Initializes a TestDeprecatedMessage with all fields set to their default value.
+   * Initializes TestDeprecatedMessage with all fields set to their default value.
    */
   initialize: function (): TestDeprecatedMessage {
     return {};
@@ -100832,7 +100832,7 @@ export const TestDeprecatedMessage = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg: Partial<ForeignMessage>): Uint8Array {
     return ForeignMessage._writeMessage(
@@ -100842,7 +100842,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ForeignMessage {
     return ForeignMessage._readMessage(
@@ -100852,14 +100852,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ForeignMessage>): string {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json: string): ForeignMessage {
     return ForeignMessage._readMessageJSON(
@@ -100869,7 +100869,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function (): ForeignMessage {
     return {
@@ -100955,35 +100955,35 @@ export const ForeignMessage = {
 
 export const TestReservedFields = {
   /**
-   * Serializes a TestReservedFields to protobuf.
+   * Serializes TestReservedFields to protobuf.
    */
   encode: function (_msg?: Partial<TestReservedFields>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestReservedFields from protobuf.
+   * Deserializes TestReservedFields from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestReservedFields {
     return {};
   },
 
   /**
-   * Serializes a TestReservedFields to JSON.
+   * Serializes TestReservedFields to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestReservedFields>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestReservedFields from JSON.
+   * Deserializes TestReservedFields from JSON.
    */
   decodeJSON: function (_json?: string): TestReservedFields {
     return {};
   },
 
   /**
-   * Initializes a TestReservedFields with all fields set to their default value.
+   * Initializes TestReservedFields with all fields set to their default value.
    */
   initialize: function (): TestReservedFields {
     return {};
@@ -101031,35 +101031,35 @@ export const TestReservedFields = {
 
 export const TestAllExtensions = {
   /**
-   * Serializes a TestAllExtensions to protobuf.
+   * Serializes TestAllExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestAllExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestAllExtensions from protobuf.
+   * Deserializes TestAllExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestAllExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestAllExtensions to JSON.
+   * Serializes TestAllExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestAllExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestAllExtensions from JSON.
+   * Deserializes TestAllExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestAllExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestAllExtensions with all fields set to their default value.
+   * Initializes TestAllExtensions with all fields set to their default value.
    */
   initialize: function (): TestAllExtensions {
     return {};
@@ -101107,7 +101107,7 @@ export const TestAllExtensions = {
 
 export const OptionalGroup_extension = {
   /**
-   * Serializes a OptionalGroup_extension to protobuf.
+   * Serializes OptionalGroup_extension to protobuf.
    */
   encode: function (msg: Partial<OptionalGroup_extension>): Uint8Array {
     return OptionalGroup_extension._writeMessage(
@@ -101117,7 +101117,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from protobuf.
+   * Deserializes OptionalGroup_extension from protobuf.
    */
   decode: function (bytes: ByteSource): OptionalGroup_extension {
     return OptionalGroup_extension._readMessage(
@@ -101127,14 +101127,14 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Serializes a OptionalGroup_extension to JSON.
+   * Serializes OptionalGroup_extension to JSON.
    */
   encodeJSON: function (msg: Partial<OptionalGroup_extension>): string {
     return JSON.stringify(OptionalGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OptionalGroup_extension from JSON.
+   * Deserializes OptionalGroup_extension from JSON.
    */
   decodeJSON: function (json: string): OptionalGroup_extension {
     return OptionalGroup_extension._readMessageJSON(
@@ -101144,7 +101144,7 @@ export const OptionalGroup_extension = {
   },
 
   /**
-   * Initializes a OptionalGroup_extension with all fields set to their default value.
+   * Initializes OptionalGroup_extension with all fields set to their default value.
    */
   initialize: function (): OptionalGroup_extension {
     return {
@@ -101218,7 +101218,7 @@ export const OptionalGroup_extension = {
 
 export const RepeatedGroup_extension = {
   /**
-   * Serializes a RepeatedGroup_extension to protobuf.
+   * Serializes RepeatedGroup_extension to protobuf.
    */
   encode: function (msg: Partial<RepeatedGroup_extension>): Uint8Array {
     return RepeatedGroup_extension._writeMessage(
@@ -101228,7 +101228,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from protobuf.
+   * Deserializes RepeatedGroup_extension from protobuf.
    */
   decode: function (bytes: ByteSource): RepeatedGroup_extension {
     return RepeatedGroup_extension._readMessage(
@@ -101238,14 +101238,14 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Serializes a RepeatedGroup_extension to JSON.
+   * Serializes RepeatedGroup_extension to JSON.
    */
   encodeJSON: function (msg: Partial<RepeatedGroup_extension>): string {
     return JSON.stringify(RepeatedGroup_extension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedGroup_extension from JSON.
+   * Deserializes RepeatedGroup_extension from JSON.
    */
   decodeJSON: function (json: string): RepeatedGroup_extension {
     return RepeatedGroup_extension._readMessageJSON(
@@ -101255,7 +101255,7 @@ export const RepeatedGroup_extension = {
   },
 
   /**
-   * Initializes a RepeatedGroup_extension with all fields set to their default value.
+   * Initializes RepeatedGroup_extension with all fields set to their default value.
    */
   initialize: function (): RepeatedGroup_extension {
     return {
@@ -101329,14 +101329,14 @@ export const RepeatedGroup_extension = {
 
 export const TestGroup = {
   /**
-   * Serializes a TestGroup to protobuf.
+   * Serializes TestGroup to protobuf.
    */
   encode: function (msg: Partial<TestGroup>): Uint8Array {
     return TestGroup._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestGroup from protobuf.
+   * Deserializes TestGroup from protobuf.
    */
   decode: function (bytes: ByteSource): TestGroup {
     return TestGroup._readMessage(
@@ -101346,21 +101346,21 @@ export const TestGroup = {
   },
 
   /**
-   * Serializes a TestGroup to JSON.
+   * Serializes TestGroup to JSON.
    */
   encodeJSON: function (msg: Partial<TestGroup>): string {
     return JSON.stringify(TestGroup._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestGroup from JSON.
+   * Deserializes TestGroup from JSON.
    */
   decodeJSON: function (json: string): TestGroup {
     return TestGroup._readMessageJSON(TestGroup.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestGroup with all fields set to their default value.
+   * Initializes TestGroup with all fields set to their default value.
    */
   initialize: function (): TestGroup {
     return {
@@ -101434,7 +101434,7 @@ export const TestGroup = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestGroup.OptionalGroup to protobuf.
+     * Serializes TestGroup.OptionalGroup to protobuf.
      */
     encode: function (msg: Partial<TestGroup.OptionalGroup>): Uint8Array {
       return TestGroup.OptionalGroup._writeMessage(
@@ -101444,7 +101444,7 @@ export const TestGroup = {
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from protobuf.
+     * Deserializes TestGroup.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestGroup.OptionalGroup {
       return TestGroup.OptionalGroup._readMessage(
@@ -101454,14 +101454,14 @@ export const TestGroup = {
     },
 
     /**
-     * Serializes a TestGroup.OptionalGroup to JSON.
+     * Serializes TestGroup.OptionalGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestGroup.OptionalGroup>): string {
       return JSON.stringify(TestGroup.OptionalGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestGroup.OptionalGroup from JSON.
+     * Deserializes TestGroup.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestGroup.OptionalGroup {
       return TestGroup.OptionalGroup._readMessageJSON(
@@ -101471,7 +101471,7 @@ export const TestGroup = {
     },
 
     /**
-     * Initializes a TestGroup.OptionalGroup with all fields set to their default value.
+     * Initializes TestGroup.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestGroup.OptionalGroup {
       return {
@@ -101546,35 +101546,35 @@ export const TestGroup = {
 
 export const TestGroupExtension = {
   /**
-   * Serializes a TestGroupExtension to protobuf.
+   * Serializes TestGroupExtension to protobuf.
    */
   encode: function (_msg?: Partial<TestGroupExtension>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestGroupExtension from protobuf.
+   * Deserializes TestGroupExtension from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestGroupExtension {
     return {};
   },
 
   /**
-   * Serializes a TestGroupExtension to JSON.
+   * Serializes TestGroupExtension to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestGroupExtension>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestGroupExtension from JSON.
+   * Deserializes TestGroupExtension from JSON.
    */
   decodeJSON: function (_json?: string): TestGroupExtension {
     return {};
   },
 
   /**
-   * Initializes a TestGroupExtension with all fields set to their default value.
+   * Initializes TestGroupExtension with all fields set to their default value.
    */
   initialize: function (): TestGroupExtension {
     return {};
@@ -101622,35 +101622,35 @@ export const TestGroupExtension = {
 
 export const TestNestedExtension = {
   /**
-   * Serializes a TestNestedExtension to protobuf.
+   * Serializes TestNestedExtension to protobuf.
    */
   encode: function (_msg?: Partial<TestNestedExtension>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestNestedExtension from protobuf.
+   * Deserializes TestNestedExtension from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestNestedExtension {
     return {};
   },
 
   /**
-   * Serializes a TestNestedExtension to JSON.
+   * Serializes TestNestedExtension to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestNestedExtension>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestNestedExtension from JSON.
+   * Deserializes TestNestedExtension from JSON.
    */
   decodeJSON: function (_json?: string): TestNestedExtension {
     return {};
   },
 
   /**
-   * Initializes a TestNestedExtension with all fields set to their default value.
+   * Initializes TestNestedExtension with all fields set to their default value.
    */
   initialize: function (): TestNestedExtension {
     return {};
@@ -101697,7 +101697,7 @@ export const TestNestedExtension = {
 
   OptionalGroup_extension: {
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to protobuf.
+     * Serializes TestNestedExtension.OptionalGroup_extension to protobuf.
      */
     encode: function (
       msg: Partial<TestNestedExtension.OptionalGroup_extension>
@@ -101709,7 +101709,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from protobuf.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -101721,7 +101721,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Serializes a TestNestedExtension.OptionalGroup_extension to JSON.
+     * Serializes TestNestedExtension.OptionalGroup_extension to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestNestedExtension.OptionalGroup_extension>
@@ -101732,7 +101732,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Deserializes a TestNestedExtension.OptionalGroup_extension from JSON.
+     * Deserializes TestNestedExtension.OptionalGroup_extension from JSON.
      */
     decodeJSON: function (
       json: string
@@ -101744,7 +101744,7 @@ export const TestNestedExtension = {
     },
 
     /**
-     * Initializes a TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
+     * Initializes TestNestedExtension.OptionalGroup_extension with all fields set to their default value.
      */
     initialize: function (): TestNestedExtension.OptionalGroup_extension {
       return {
@@ -101819,7 +101819,7 @@ export const TestNestedExtension = {
 
 export const TestChildExtension = {
   /**
-   * Serializes a TestChildExtension to protobuf.
+   * Serializes TestChildExtension to protobuf.
    */
   encode: function (msg: Partial<TestChildExtension>): Uint8Array {
     return TestChildExtension._writeMessage(
@@ -101829,7 +101829,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Deserializes a TestChildExtension from protobuf.
+   * Deserializes TestChildExtension from protobuf.
    */
   decode: function (bytes: ByteSource): TestChildExtension {
     return TestChildExtension._readMessage(
@@ -101839,14 +101839,14 @@ export const TestChildExtension = {
   },
 
   /**
-   * Serializes a TestChildExtension to JSON.
+   * Serializes TestChildExtension to JSON.
    */
   encodeJSON: function (msg: Partial<TestChildExtension>): string {
     return JSON.stringify(TestChildExtension._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestChildExtension from JSON.
+   * Deserializes TestChildExtension from JSON.
    */
   decodeJSON: function (json: string): TestChildExtension {
     return TestChildExtension._readMessageJSON(
@@ -101856,7 +101856,7 @@ export const TestChildExtension = {
   },
 
   /**
-   * Initializes a TestChildExtension with all fields set to their default value.
+   * Initializes TestChildExtension with all fields set to their default value.
    */
   initialize: function (): TestChildExtension {
     return {
@@ -101975,7 +101975,7 @@ export const TestChildExtension = {
 
 export const TestRequired = {
   /**
-   * Serializes a TestRequired to protobuf.
+   * Serializes TestRequired to protobuf.
    */
   encode: function (msg: Partial<TestRequired>): Uint8Array {
     return TestRequired._writeMessage(
@@ -101985,7 +101985,7 @@ export const TestRequired = {
   },
 
   /**
-   * Deserializes a TestRequired from protobuf.
+   * Deserializes TestRequired from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequired {
     return TestRequired._readMessage(
@@ -101995,14 +101995,14 @@ export const TestRequired = {
   },
 
   /**
-   * Serializes a TestRequired to JSON.
+   * Serializes TestRequired to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequired>): string {
     return JSON.stringify(TestRequired._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequired from JSON.
+   * Deserializes TestRequired from JSON.
    */
   decodeJSON: function (json: string): TestRequired {
     return TestRequired._readMessageJSON(
@@ -102012,7 +102012,7 @@ export const TestRequired = {
   },
 
   /**
-   * Initializes a TestRequired with all fields set to their default value.
+   * Initializes TestRequired with all fields set to their default value.
    */
   initialize: function (): TestRequired {
     return {
@@ -102563,7 +102563,7 @@ export const TestRequired = {
 
 export const TestRequiredForeign = {
   /**
-   * Serializes a TestRequiredForeign to protobuf.
+   * Serializes TestRequiredForeign to protobuf.
    */
   encode: function (msg: Partial<TestRequiredForeign>): Uint8Array {
     return TestRequiredForeign._writeMessage(
@@ -102573,7 +102573,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Deserializes a TestRequiredForeign from protobuf.
+   * Deserializes TestRequiredForeign from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredForeign {
     return TestRequiredForeign._readMessage(
@@ -102583,14 +102583,14 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Serializes a TestRequiredForeign to JSON.
+   * Serializes TestRequiredForeign to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredForeign>): string {
     return JSON.stringify(TestRequiredForeign._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredForeign from JSON.
+   * Deserializes TestRequiredForeign from JSON.
    */
   decodeJSON: function (json: string): TestRequiredForeign {
     return TestRequiredForeign._readMessageJSON(
@@ -102600,7 +102600,7 @@ export const TestRequiredForeign = {
   },
 
   /**
-   * Initializes a TestRequiredForeign with all fields set to their default value.
+   * Initializes TestRequiredForeign with all fields set to their default value.
    */
   initialize: function (): TestRequiredForeign {
     return {
@@ -102723,7 +102723,7 @@ export const TestRequiredForeign = {
 
 export const TestRequiredMessage = {
   /**
-   * Serializes a TestRequiredMessage to protobuf.
+   * Serializes TestRequiredMessage to protobuf.
    */
   encode: function (msg: Partial<TestRequiredMessage>): Uint8Array {
     return TestRequiredMessage._writeMessage(
@@ -102733,7 +102733,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Deserializes a TestRequiredMessage from protobuf.
+   * Deserializes TestRequiredMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredMessage {
     return TestRequiredMessage._readMessage(
@@ -102743,14 +102743,14 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Serializes a TestRequiredMessage to JSON.
+   * Serializes TestRequiredMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredMessage>): string {
     return JSON.stringify(TestRequiredMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessage from JSON.
+   * Deserializes TestRequiredMessage from JSON.
    */
   decodeJSON: function (json: string): TestRequiredMessage {
     return TestRequiredMessage._readMessageJSON(
@@ -102760,7 +102760,7 @@ export const TestRequiredMessage = {
   },
 
   /**
-   * Initializes a TestRequiredMessage with all fields set to their default value.
+   * Initializes TestRequiredMessage with all fields set to their default value.
    */
   initialize: function (): TestRequiredMessage {
     return {
@@ -102890,7 +102890,7 @@ export const TestRequiredMessage = {
 
 export const TestForeignNested = {
   /**
-   * Serializes a TestForeignNested to protobuf.
+   * Serializes TestForeignNested to protobuf.
    */
   encode: function (msg: Partial<TestForeignNested>): Uint8Array {
     return TestForeignNested._writeMessage(
@@ -102900,7 +102900,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Deserializes a TestForeignNested from protobuf.
+   * Deserializes TestForeignNested from protobuf.
    */
   decode: function (bytes: ByteSource): TestForeignNested {
     return TestForeignNested._readMessage(
@@ -102910,14 +102910,14 @@ export const TestForeignNested = {
   },
 
   /**
-   * Serializes a TestForeignNested to JSON.
+   * Serializes TestForeignNested to JSON.
    */
   encodeJSON: function (msg: Partial<TestForeignNested>): string {
     return JSON.stringify(TestForeignNested._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestForeignNested from JSON.
+   * Deserializes TestForeignNested from JSON.
    */
   decodeJSON: function (json: string): TestForeignNested {
     return TestForeignNested._readMessageJSON(
@@ -102927,7 +102927,7 @@ export const TestForeignNested = {
   },
 
   /**
-   * Initializes a TestForeignNested with all fields set to their default value.
+   * Initializes TestForeignNested with all fields set to their default value.
    */
   initialize: function (): TestForeignNested {
     return {
@@ -103015,35 +103015,35 @@ export const TestForeignNested = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestEmptyMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestEmptyMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessage {
     return {};
@@ -103091,7 +103091,7 @@ export const TestEmptyMessage = {
 
 export const TestEmptyMessageWithExtensions = {
   /**
-   * Serializes a TestEmptyMessageWithExtensions to protobuf.
+   * Serializes TestEmptyMessageWithExtensions to protobuf.
    */
   encode: function (
     _msg?: Partial<TestEmptyMessageWithExtensions>
@@ -103100,14 +103100,14 @@ export const TestEmptyMessageWithExtensions = {
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from protobuf.
+   * Deserializes TestEmptyMessageWithExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessageWithExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessageWithExtensions to JSON.
+   * Serializes TestEmptyMessageWithExtensions to JSON.
    */
   encodeJSON: function (
     _msg?: Partial<TestEmptyMessageWithExtensions>
@@ -103116,14 +103116,14 @@ export const TestEmptyMessageWithExtensions = {
   },
 
   /**
-   * Deserializes a TestEmptyMessageWithExtensions from JSON.
+   * Deserializes TestEmptyMessageWithExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessageWithExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessageWithExtensions with all fields set to their default value.
+   * Initializes TestEmptyMessageWithExtensions with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessageWithExtensions {
     return {};
@@ -103171,35 +103171,35 @@ export const TestEmptyMessageWithExtensions = {
 
 export const TestPickleNestedMessage = {
   /**
-   * Serializes a TestPickleNestedMessage to protobuf.
+   * Serializes TestPickleNestedMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestPickleNestedMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from protobuf.
+   * Deserializes TestPickleNestedMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestPickleNestedMessage {
     return {};
   },
 
   /**
-   * Serializes a TestPickleNestedMessage to JSON.
+   * Serializes TestPickleNestedMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestPickleNestedMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPickleNestedMessage from JSON.
+   * Deserializes TestPickleNestedMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestPickleNestedMessage {
     return {};
   },
 
   /**
-   * Initializes a TestPickleNestedMessage with all fields set to their default value.
+   * Initializes TestPickleNestedMessage with all fields set to their default value.
    */
   initialize: function (): TestPickleNestedMessage {
     return {};
@@ -103246,7 +103246,7 @@ export const TestPickleNestedMessage = {
 
   NestedMessage: {
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to protobuf.
+     * Serializes TestPickleNestedMessage.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestPickleNestedMessage.NestedMessage>
@@ -103258,7 +103258,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from protobuf.
+     * Deserializes TestPickleNestedMessage.NestedMessage from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -103270,7 +103270,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Serializes a TestPickleNestedMessage.NestedMessage to JSON.
+     * Serializes TestPickleNestedMessage.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestPickleNestedMessage.NestedMessage>
@@ -103281,7 +103281,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Deserializes a TestPickleNestedMessage.NestedMessage from JSON.
+     * Deserializes TestPickleNestedMessage.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestPickleNestedMessage.NestedMessage {
       return TestPickleNestedMessage.NestedMessage._readMessageJSON(
@@ -103291,7 +103291,7 @@ export const TestPickleNestedMessage = {
     },
 
     /**
-     * Initializes a TestPickleNestedMessage.NestedMessage with all fields set to their default value.
+     * Initializes TestPickleNestedMessage.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestPickleNestedMessage.NestedMessage {
       return {
@@ -103364,7 +103364,7 @@ export const TestPickleNestedMessage = {
 
     NestedNestedMessage: {
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to protobuf.
        */
       encode: function (
         msg: Partial<TestPickleNestedMessage.NestedMessage.NestedNestedMessage>
@@ -103376,7 +103376,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -103388,7 +103388,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Serializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
+       * Serializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestPickleNestedMessage.NestedMessage.NestedNestedMessage>
@@ -103401,7 +103401,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Deserializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
+       * Deserializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage from JSON.
        */
       decodeJSON: function (
         json: string
@@ -103413,7 +103413,7 @@ export const TestPickleNestedMessage = {
       },
 
       /**
-       * Initializes a TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
+       * Initializes TestPickleNestedMessage.NestedMessage.NestedNestedMessage with all fields set to their default value.
        */
       initialize:
         function (): TestPickleNestedMessage.NestedMessage.NestedNestedMessage {
@@ -103490,35 +103490,35 @@ export const TestPickleNestedMessage = {
 
 export const TestMultipleExtensionRanges = {
   /**
-   * Serializes a TestMultipleExtensionRanges to protobuf.
+   * Serializes TestMultipleExtensionRanges to protobuf.
    */
   encode: function (_msg?: Partial<TestMultipleExtensionRanges>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from protobuf.
+   * Deserializes TestMultipleExtensionRanges from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestMultipleExtensionRanges {
     return {};
   },
 
   /**
-   * Serializes a TestMultipleExtensionRanges to JSON.
+   * Serializes TestMultipleExtensionRanges to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestMultipleExtensionRanges>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestMultipleExtensionRanges from JSON.
+   * Deserializes TestMultipleExtensionRanges from JSON.
    */
   decodeJSON: function (_json?: string): TestMultipleExtensionRanges {
     return {};
   },
 
   /**
-   * Initializes a TestMultipleExtensionRanges with all fields set to their default value.
+   * Initializes TestMultipleExtensionRanges with all fields set to their default value.
    */
   initialize: function (): TestMultipleExtensionRanges {
     return {};
@@ -103566,7 +103566,7 @@ export const TestMultipleExtensionRanges = {
 
 export const TestReallyLargeTagNumber = {
   /**
-   * Serializes a TestReallyLargeTagNumber to protobuf.
+   * Serializes TestReallyLargeTagNumber to protobuf.
    */
   encode: function (msg: Partial<TestReallyLargeTagNumber>): Uint8Array {
     return TestReallyLargeTagNumber._writeMessage(
@@ -103576,7 +103576,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from protobuf.
+   * Deserializes TestReallyLargeTagNumber from protobuf.
    */
   decode: function (bytes: ByteSource): TestReallyLargeTagNumber {
     return TestReallyLargeTagNumber._readMessage(
@@ -103586,14 +103586,14 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Serializes a TestReallyLargeTagNumber to JSON.
+   * Serializes TestReallyLargeTagNumber to JSON.
    */
   encodeJSON: function (msg: Partial<TestReallyLargeTagNumber>): string {
     return JSON.stringify(TestReallyLargeTagNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestReallyLargeTagNumber from JSON.
+   * Deserializes TestReallyLargeTagNumber from JSON.
    */
   decodeJSON: function (json: string): TestReallyLargeTagNumber {
     return TestReallyLargeTagNumber._readMessageJSON(
@@ -103603,7 +103603,7 @@ export const TestReallyLargeTagNumber = {
   },
 
   /**
-   * Initializes a TestReallyLargeTagNumber with all fields set to their default value.
+   * Initializes TestReallyLargeTagNumber with all fields set to their default value.
    */
   initialize: function (): TestReallyLargeTagNumber {
     return {
@@ -103692,7 +103692,7 @@ export const TestReallyLargeTagNumber = {
 
 export const TestRecursiveMessage = {
   /**
-   * Serializes a TestRecursiveMessage to protobuf.
+   * Serializes TestRecursiveMessage to protobuf.
    */
   encode: function (msg: Partial<TestRecursiveMessage>): Uint8Array {
     return TestRecursiveMessage._writeMessage(
@@ -103702,7 +103702,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from protobuf.
+   * Deserializes TestRecursiveMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRecursiveMessage {
     return TestRecursiveMessage._readMessage(
@@ -103712,14 +103712,14 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMessage to JSON.
+   * Serializes TestRecursiveMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRecursiveMessage>): string {
     return JSON.stringify(TestRecursiveMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMessage from JSON.
+   * Deserializes TestRecursiveMessage from JSON.
    */
   decodeJSON: function (json: string): TestRecursiveMessage {
     return TestRecursiveMessage._readMessageJSON(
@@ -103729,7 +103729,7 @@ export const TestRecursiveMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMessage with all fields set to their default value.
+   * Initializes TestRecursiveMessage with all fields set to their default value.
    */
   initialize: function (): TestRecursiveMessage {
     return {
@@ -103823,7 +103823,7 @@ export const TestRecursiveMessage = {
 
 export const TestMutualRecursionA = {
   /**
-   * Serializes a TestMutualRecursionA to protobuf.
+   * Serializes TestMutualRecursionA to protobuf.
    */
   encode: function (msg: Partial<TestMutualRecursionA>): Uint8Array {
     return TestMutualRecursionA._writeMessage(
@@ -103833,7 +103833,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from protobuf.
+   * Deserializes TestMutualRecursionA from protobuf.
    */
   decode: function (bytes: ByteSource): TestMutualRecursionA {
     return TestMutualRecursionA._readMessage(
@@ -103843,14 +103843,14 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Serializes a TestMutualRecursionA to JSON.
+   * Serializes TestMutualRecursionA to JSON.
    */
   encodeJSON: function (msg: Partial<TestMutualRecursionA>): string {
     return JSON.stringify(TestMutualRecursionA._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionA from JSON.
+   * Deserializes TestMutualRecursionA from JSON.
    */
   decodeJSON: function (json: string): TestMutualRecursionA {
     return TestMutualRecursionA._readMessageJSON(
@@ -103860,7 +103860,7 @@ export const TestMutualRecursionA = {
   },
 
   /**
-   * Initializes a TestMutualRecursionA with all fields set to their default value.
+   * Initializes TestMutualRecursionA with all fields set to their default value.
    */
   initialize: function (): TestMutualRecursionA {
     return {
@@ -103938,7 +103938,7 @@ export const TestMutualRecursionA = {
 
   SubMessage: {
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to protobuf.
+     * Serializes TestMutualRecursionA.SubMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestMutualRecursionA.SubMessage>
@@ -103950,7 +103950,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from protobuf.
+     * Deserializes TestMutualRecursionA.SubMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestMutualRecursionA.SubMessage {
       return TestMutualRecursionA.SubMessage._readMessage(
@@ -103960,7 +103960,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubMessage to JSON.
+     * Serializes TestMutualRecursionA.SubMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestMutualRecursionA.SubMessage>
@@ -103971,7 +103971,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubMessage from JSON.
+     * Deserializes TestMutualRecursionA.SubMessage from JSON.
      */
     decodeJSON: function (json: string): TestMutualRecursionA.SubMessage {
       return TestMutualRecursionA.SubMessage._readMessageJSON(
@@ -103981,7 +103981,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubMessage with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubMessage with all fields set to their default value.
      */
     initialize: function (): TestMutualRecursionA.SubMessage {
       return {
@@ -104060,7 +104060,7 @@ export const TestMutualRecursionA = {
 
   SubGroup: {
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to protobuf.
+     * Serializes TestMutualRecursionA.SubGroup to protobuf.
      */
     encode: function (msg: Partial<TestMutualRecursionA.SubGroup>): Uint8Array {
       return TestMutualRecursionA.SubGroup._writeMessage(
@@ -104070,7 +104070,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from protobuf.
+     * Deserializes TestMutualRecursionA.SubGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestMutualRecursionA.SubGroup {
       return TestMutualRecursionA.SubGroup._readMessage(
@@ -104080,7 +104080,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Serializes a TestMutualRecursionA.SubGroup to JSON.
+     * Serializes TestMutualRecursionA.SubGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestMutualRecursionA.SubGroup>): string {
       return JSON.stringify(
@@ -104089,7 +104089,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Deserializes a TestMutualRecursionA.SubGroup from JSON.
+     * Deserializes TestMutualRecursionA.SubGroup from JSON.
      */
     decodeJSON: function (json: string): TestMutualRecursionA.SubGroup {
       return TestMutualRecursionA.SubGroup._readMessageJSON(
@@ -104099,7 +104099,7 @@ export const TestMutualRecursionA = {
     },
 
     /**
-     * Initializes a TestMutualRecursionA.SubGroup with all fields set to their default value.
+     * Initializes TestMutualRecursionA.SubGroup with all fields set to their default value.
      */
     initialize: function (): TestMutualRecursionA.SubGroup {
       return {
@@ -104208,7 +104208,7 @@ export const TestMutualRecursionA = {
 
 export const TestMutualRecursionB = {
   /**
-   * Serializes a TestMutualRecursionB to protobuf.
+   * Serializes TestMutualRecursionB to protobuf.
    */
   encode: function (msg: Partial<TestMutualRecursionB>): Uint8Array {
     return TestMutualRecursionB._writeMessage(
@@ -104218,7 +104218,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from protobuf.
+   * Deserializes TestMutualRecursionB from protobuf.
    */
   decode: function (bytes: ByteSource): TestMutualRecursionB {
     return TestMutualRecursionB._readMessage(
@@ -104228,14 +104228,14 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Serializes a TestMutualRecursionB to JSON.
+   * Serializes TestMutualRecursionB to JSON.
    */
   encodeJSON: function (msg: Partial<TestMutualRecursionB>): string {
     return JSON.stringify(TestMutualRecursionB._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMutualRecursionB from JSON.
+   * Deserializes TestMutualRecursionB from JSON.
    */
   decodeJSON: function (json: string): TestMutualRecursionB {
     return TestMutualRecursionB._readMessageJSON(
@@ -104245,7 +104245,7 @@ export const TestMutualRecursionB = {
   },
 
   /**
-   * Initializes a TestMutualRecursionB with all fields set to their default value.
+   * Initializes TestMutualRecursionB with all fields set to their default value.
    */
   initialize: function (): TestMutualRecursionB {
     return {
@@ -104339,7 +104339,7 @@ export const TestMutualRecursionB = {
 
 export const TestIsInitialized = {
   /**
-   * Serializes a TestIsInitialized to protobuf.
+   * Serializes TestIsInitialized to protobuf.
    */
   encode: function (msg: Partial<TestIsInitialized>): Uint8Array {
     return TestIsInitialized._writeMessage(
@@ -104349,7 +104349,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Deserializes a TestIsInitialized from protobuf.
+   * Deserializes TestIsInitialized from protobuf.
    */
   decode: function (bytes: ByteSource): TestIsInitialized {
     return TestIsInitialized._readMessage(
@@ -104359,14 +104359,14 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Serializes a TestIsInitialized to JSON.
+   * Serializes TestIsInitialized to JSON.
    */
   encodeJSON: function (msg: Partial<TestIsInitialized>): string {
     return JSON.stringify(TestIsInitialized._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestIsInitialized from JSON.
+   * Deserializes TestIsInitialized from JSON.
    */
   decodeJSON: function (json: string): TestIsInitialized {
     return TestIsInitialized._readMessageJSON(
@@ -104376,7 +104376,7 @@ export const TestIsInitialized = {
   },
 
   /**
-   * Initializes a TestIsInitialized with all fields set to their default value.
+   * Initializes TestIsInitialized with all fields set to their default value.
    */
   initialize: function (): TestIsInitialized {
     return {
@@ -104463,7 +104463,7 @@ export const TestIsInitialized = {
 
   SubMessage: {
     /**
-     * Serializes a TestIsInitialized.SubMessage to protobuf.
+     * Serializes TestIsInitialized.SubMessage to protobuf.
      */
     encode: function (
       _msg?: Partial<TestIsInitialized.SubMessage>
@@ -104472,14 +104472,14 @@ export const TestIsInitialized = {
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from protobuf.
+     * Deserializes TestIsInitialized.SubMessage from protobuf.
      */
     decode: function (_bytes?: ByteSource): TestIsInitialized.SubMessage {
       return {};
     },
 
     /**
-     * Serializes a TestIsInitialized.SubMessage to JSON.
+     * Serializes TestIsInitialized.SubMessage to JSON.
      */
     encodeJSON: function (
       _msg?: Partial<TestIsInitialized.SubMessage>
@@ -104488,14 +104488,14 @@ export const TestIsInitialized = {
     },
 
     /**
-     * Deserializes a TestIsInitialized.SubMessage from JSON.
+     * Deserializes TestIsInitialized.SubMessage from JSON.
      */
     decodeJSON: function (_json?: string): TestIsInitialized.SubMessage {
       return {};
     },
 
     /**
-     * Initializes a TestIsInitialized.SubMessage with all fields set to their default value.
+     * Initializes TestIsInitialized.SubMessage with all fields set to their default value.
      */
     initialize: function (): TestIsInitialized.SubMessage {
       return {};
@@ -104542,7 +104542,7 @@ export const TestIsInitialized = {
 
     SubGroup: {
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to protobuf.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to protobuf.
        */
       encode: function (
         msg: Partial<TestIsInitialized.SubMessage.SubGroup>
@@ -104554,7 +104554,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from protobuf.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -104566,7 +104566,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Serializes a TestIsInitialized.SubMessage.SubGroup to JSON.
+       * Serializes TestIsInitialized.SubMessage.SubGroup to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestIsInitialized.SubMessage.SubGroup>
@@ -104577,7 +104577,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Deserializes a TestIsInitialized.SubMessage.SubGroup from JSON.
+       * Deserializes TestIsInitialized.SubMessage.SubGroup from JSON.
        */
       decodeJSON: function (
         json: string
@@ -104589,7 +104589,7 @@ export const TestIsInitialized = {
       },
 
       /**
-       * Initializes a TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
+       * Initializes TestIsInitialized.SubMessage.SubGroup with all fields set to their default value.
        */
       initialize: function (): TestIsInitialized.SubMessage.SubGroup {
         return {
@@ -104665,7 +104665,7 @@ export const TestIsInitialized = {
 
 export const TestDupFieldNumber = {
   /**
-   * Serializes a TestDupFieldNumber to protobuf.
+   * Serializes TestDupFieldNumber to protobuf.
    */
   encode: function (msg: Partial<TestDupFieldNumber>): Uint8Array {
     return TestDupFieldNumber._writeMessage(
@@ -104675,7 +104675,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from protobuf.
+   * Deserializes TestDupFieldNumber from protobuf.
    */
   decode: function (bytes: ByteSource): TestDupFieldNumber {
     return TestDupFieldNumber._readMessage(
@@ -104685,14 +104685,14 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Serializes a TestDupFieldNumber to JSON.
+   * Serializes TestDupFieldNumber to JSON.
    */
   encodeJSON: function (msg: Partial<TestDupFieldNumber>): string {
     return JSON.stringify(TestDupFieldNumber._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDupFieldNumber from JSON.
+   * Deserializes TestDupFieldNumber from JSON.
    */
   decodeJSON: function (json: string): TestDupFieldNumber {
     return TestDupFieldNumber._readMessageJSON(
@@ -104702,7 +104702,7 @@ export const TestDupFieldNumber = {
   },
 
   /**
-   * Initializes a TestDupFieldNumber with all fields set to their default value.
+   * Initializes TestDupFieldNumber with all fields set to their default value.
    */
   initialize: function (): TestDupFieldNumber {
     return {
@@ -104775,7 +104775,7 @@ export const TestDupFieldNumber = {
 
   Foo: {
     /**
-     * Serializes a TestDupFieldNumber.Foo to protobuf.
+     * Serializes TestDupFieldNumber.Foo to protobuf.
      */
     encode: function (msg: Partial<TestDupFieldNumber.Foo>): Uint8Array {
       return TestDupFieldNumber.Foo._writeMessage(
@@ -104785,7 +104785,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from protobuf.
+     * Deserializes TestDupFieldNumber.Foo from protobuf.
      */
     decode: function (bytes: ByteSource): TestDupFieldNumber.Foo {
       return TestDupFieldNumber.Foo._readMessage(
@@ -104795,14 +104795,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Foo to JSON.
+     * Serializes TestDupFieldNumber.Foo to JSON.
      */
     encodeJSON: function (msg: Partial<TestDupFieldNumber.Foo>): string {
       return JSON.stringify(TestDupFieldNumber.Foo._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Foo from JSON.
+     * Deserializes TestDupFieldNumber.Foo from JSON.
      */
     decodeJSON: function (json: string): TestDupFieldNumber.Foo {
       return TestDupFieldNumber.Foo._readMessageJSON(
@@ -104812,7 +104812,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Foo with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Foo with all fields set to their default value.
      */
     initialize: function (): TestDupFieldNumber.Foo {
       return {
@@ -104886,7 +104886,7 @@ export const TestDupFieldNumber = {
 
   Bar: {
     /**
-     * Serializes a TestDupFieldNumber.Bar to protobuf.
+     * Serializes TestDupFieldNumber.Bar to protobuf.
      */
     encode: function (msg: Partial<TestDupFieldNumber.Bar>): Uint8Array {
       return TestDupFieldNumber.Bar._writeMessage(
@@ -104896,7 +104896,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from protobuf.
+     * Deserializes TestDupFieldNumber.Bar from protobuf.
      */
     decode: function (bytes: ByteSource): TestDupFieldNumber.Bar {
       return TestDupFieldNumber.Bar._readMessage(
@@ -104906,14 +104906,14 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Serializes a TestDupFieldNumber.Bar to JSON.
+     * Serializes TestDupFieldNumber.Bar to JSON.
      */
     encodeJSON: function (msg: Partial<TestDupFieldNumber.Bar>): string {
       return JSON.stringify(TestDupFieldNumber.Bar._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestDupFieldNumber.Bar from JSON.
+     * Deserializes TestDupFieldNumber.Bar from JSON.
      */
     decodeJSON: function (json: string): TestDupFieldNumber.Bar {
       return TestDupFieldNumber.Bar._readMessageJSON(
@@ -104923,7 +104923,7 @@ export const TestDupFieldNumber = {
     },
 
     /**
-     * Initializes a TestDupFieldNumber.Bar with all fields set to their default value.
+     * Initializes TestDupFieldNumber.Bar with all fields set to their default value.
      */
     initialize: function (): TestDupFieldNumber.Bar {
       return {
@@ -104998,7 +104998,7 @@ export const TestDupFieldNumber = {
 
 export const TestEagerMessage = {
   /**
-   * Serializes a TestEagerMessage to protobuf.
+   * Serializes TestEagerMessage to protobuf.
    */
   encode: function (msg: Partial<TestEagerMessage>): Uint8Array {
     return TestEagerMessage._writeMessage(
@@ -105008,7 +105008,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Deserializes a TestEagerMessage from protobuf.
+   * Deserializes TestEagerMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestEagerMessage {
     return TestEagerMessage._readMessage(
@@ -105018,14 +105018,14 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Serializes a TestEagerMessage to JSON.
+   * Serializes TestEagerMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestEagerMessage>): string {
     return JSON.stringify(TestEagerMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestEagerMessage from JSON.
+   * Deserializes TestEagerMessage from JSON.
    */
   decodeJSON: function (json: string): TestEagerMessage {
     return TestEagerMessage._readMessageJSON(
@@ -105035,7 +105035,7 @@ export const TestEagerMessage = {
   },
 
   /**
-   * Initializes a TestEagerMessage with all fields set to their default value.
+   * Initializes TestEagerMessage with all fields set to their default value.
    */
   initialize: function (): TestEagerMessage {
     return {
@@ -105114,7 +105114,7 @@ export const TestEagerMessage = {
 
 export const TestLazyMessage = {
   /**
-   * Serializes a TestLazyMessage to protobuf.
+   * Serializes TestLazyMessage to protobuf.
    */
   encode: function (msg: Partial<TestLazyMessage>): Uint8Array {
     return TestLazyMessage._writeMessage(
@@ -105124,7 +105124,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Deserializes a TestLazyMessage from protobuf.
+   * Deserializes TestLazyMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestLazyMessage {
     return TestLazyMessage._readMessage(
@@ -105134,14 +105134,14 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Serializes a TestLazyMessage to JSON.
+   * Serializes TestLazyMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestLazyMessage>): string {
     return JSON.stringify(TestLazyMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestLazyMessage from JSON.
+   * Deserializes TestLazyMessage from JSON.
    */
   decodeJSON: function (json: string): TestLazyMessage {
     return TestLazyMessage._readMessageJSON(
@@ -105151,7 +105151,7 @@ export const TestLazyMessage = {
   },
 
   /**
-   * Initializes a TestLazyMessage with all fields set to their default value.
+   * Initializes TestLazyMessage with all fields set to their default value.
    */
   initialize: function (): TestLazyMessage {
     return {
@@ -105230,7 +105230,7 @@ export const TestLazyMessage = {
 
 export const TestNestedMessageHasBits = {
   /**
-   * Serializes a TestNestedMessageHasBits to protobuf.
+   * Serializes TestNestedMessageHasBits to protobuf.
    */
   encode: function (msg: Partial<TestNestedMessageHasBits>): Uint8Array {
     return TestNestedMessageHasBits._writeMessage(
@@ -105240,7 +105240,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from protobuf.
+   * Deserializes TestNestedMessageHasBits from protobuf.
    */
   decode: function (bytes: ByteSource): TestNestedMessageHasBits {
     return TestNestedMessageHasBits._readMessage(
@@ -105250,14 +105250,14 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Serializes a TestNestedMessageHasBits to JSON.
+   * Serializes TestNestedMessageHasBits to JSON.
    */
   encodeJSON: function (msg: Partial<TestNestedMessageHasBits>): string {
     return JSON.stringify(TestNestedMessageHasBits._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestNestedMessageHasBits from JSON.
+   * Deserializes TestNestedMessageHasBits from JSON.
    */
   decodeJSON: function (json: string): TestNestedMessageHasBits {
     return TestNestedMessageHasBits._readMessageJSON(
@@ -105267,7 +105267,7 @@ export const TestNestedMessageHasBits = {
   },
 
   /**
-   * Initializes a TestNestedMessageHasBits with all fields set to their default value.
+   * Initializes TestNestedMessageHasBits with all fields set to their default value.
    */
   initialize: function (): TestNestedMessageHasBits {
     return {
@@ -105360,7 +105360,7 @@ export const TestNestedMessageHasBits = {
 
   NestedMessage: {
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to protobuf.
+     * Serializes TestNestedMessageHasBits.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestNestedMessageHasBits.NestedMessage>
@@ -105372,7 +105372,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from protobuf.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -105384,7 +105384,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Serializes a TestNestedMessageHasBits.NestedMessage to JSON.
+     * Serializes TestNestedMessageHasBits.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestNestedMessageHasBits.NestedMessage>
@@ -105395,7 +105395,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Deserializes a TestNestedMessageHasBits.NestedMessage from JSON.
+     * Deserializes TestNestedMessageHasBits.NestedMessage from JSON.
      */
     decodeJSON: function (
       json: string
@@ -105407,7 +105407,7 @@ export const TestNestedMessageHasBits = {
     },
 
     /**
-     * Initializes a TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
+     * Initializes TestNestedMessageHasBits.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestNestedMessageHasBits.NestedMessage {
       return {
@@ -105513,7 +105513,7 @@ export const TestNestedMessageHasBits = {
 
 export const TestCamelCaseFieldNames = {
   /**
-   * Serializes a TestCamelCaseFieldNames to protobuf.
+   * Serializes TestCamelCaseFieldNames to protobuf.
    */
   encode: function (msg: Partial<TestCamelCaseFieldNames>): Uint8Array {
     return TestCamelCaseFieldNames._writeMessage(
@@ -105523,7 +105523,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from protobuf.
+   * Deserializes TestCamelCaseFieldNames from protobuf.
    */
   decode: function (bytes: ByteSource): TestCamelCaseFieldNames {
     return TestCamelCaseFieldNames._readMessage(
@@ -105533,14 +105533,14 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Serializes a TestCamelCaseFieldNames to JSON.
+   * Serializes TestCamelCaseFieldNames to JSON.
    */
   encodeJSON: function (msg: Partial<TestCamelCaseFieldNames>): string {
     return JSON.stringify(TestCamelCaseFieldNames._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCamelCaseFieldNames from JSON.
+   * Deserializes TestCamelCaseFieldNames from JSON.
    */
   decodeJSON: function (json: string): TestCamelCaseFieldNames {
     return TestCamelCaseFieldNames._readMessageJSON(
@@ -105550,7 +105550,7 @@ export const TestCamelCaseFieldNames = {
   },
 
   /**
-   * Initializes a TestCamelCaseFieldNames with all fields set to their default value.
+   * Initializes TestCamelCaseFieldNames with all fields set to their default value.
    */
   initialize: function (): TestCamelCaseFieldNames {
     return {
@@ -105809,7 +105809,7 @@ export const TestCamelCaseFieldNames = {
 
 export const TestFieldOrderings = {
   /**
-   * Serializes a TestFieldOrderings to protobuf.
+   * Serializes TestFieldOrderings to protobuf.
    */
   encode: function (msg: Partial<TestFieldOrderings>): Uint8Array {
     return TestFieldOrderings._writeMessage(
@@ -105819,7 +105819,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Deserializes a TestFieldOrderings from protobuf.
+   * Deserializes TestFieldOrderings from protobuf.
    */
   decode: function (bytes: ByteSource): TestFieldOrderings {
     return TestFieldOrderings._readMessage(
@@ -105829,14 +105829,14 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Serializes a TestFieldOrderings to JSON.
+   * Serializes TestFieldOrderings to JSON.
    */
   encodeJSON: function (msg: Partial<TestFieldOrderings>): string {
     return JSON.stringify(TestFieldOrderings._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestFieldOrderings from JSON.
+   * Deserializes TestFieldOrderings from JSON.
    */
   decodeJSON: function (json: string): TestFieldOrderings {
     return TestFieldOrderings._readMessageJSON(
@@ -105846,7 +105846,7 @@ export const TestFieldOrderings = {
   },
 
   /**
-   * Initializes a TestFieldOrderings with all fields set to their default value.
+   * Initializes TestFieldOrderings with all fields set to their default value.
    */
   initialize: function (): TestFieldOrderings {
     return {
@@ -105983,7 +105983,7 @@ export const TestFieldOrderings = {
 
   NestedMessage: {
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to protobuf.
+     * Serializes TestFieldOrderings.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestFieldOrderings.NestedMessage>
@@ -105995,7 +105995,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from protobuf.
+     * Deserializes TestFieldOrderings.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestFieldOrderings.NestedMessage {
       return TestFieldOrderings.NestedMessage._readMessage(
@@ -106005,7 +106005,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Serializes a TestFieldOrderings.NestedMessage to JSON.
+     * Serializes TestFieldOrderings.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestFieldOrderings.NestedMessage>
@@ -106016,7 +106016,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Deserializes a TestFieldOrderings.NestedMessage from JSON.
+     * Deserializes TestFieldOrderings.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestFieldOrderings.NestedMessage {
       return TestFieldOrderings.NestedMessage._readMessageJSON(
@@ -106026,7 +106026,7 @@ export const TestFieldOrderings = {
     },
 
     /**
-     * Initializes a TestFieldOrderings.NestedMessage with all fields set to their default value.
+     * Initializes TestFieldOrderings.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestFieldOrderings.NestedMessage {
       return {
@@ -106116,7 +106116,7 @@ export const TestFieldOrderings = {
 
 export const TestExtensionOrderings1 = {
   /**
-   * Serializes a TestExtensionOrderings1 to protobuf.
+   * Serializes TestExtensionOrderings1 to protobuf.
    */
   encode: function (msg: Partial<TestExtensionOrderings1>): Uint8Array {
     return TestExtensionOrderings1._writeMessage(
@@ -106126,7 +106126,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from protobuf.
+   * Deserializes TestExtensionOrderings1 from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionOrderings1 {
     return TestExtensionOrderings1._readMessage(
@@ -106136,14 +106136,14 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings1 to JSON.
+   * Serializes TestExtensionOrderings1 to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionOrderings1>): string {
     return JSON.stringify(TestExtensionOrderings1._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings1 from JSON.
+   * Deserializes TestExtensionOrderings1 from JSON.
    */
   decodeJSON: function (json: string): TestExtensionOrderings1 {
     return TestExtensionOrderings1._readMessageJSON(
@@ -106153,7 +106153,7 @@ export const TestExtensionOrderings1 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings1 with all fields set to their default value.
+   * Initializes TestExtensionOrderings1 with all fields set to their default value.
    */
   initialize: function (): TestExtensionOrderings1 {
     return {
@@ -106227,7 +106227,7 @@ export const TestExtensionOrderings1 = {
 
 export const TestExtensionOrderings2 = {
   /**
-   * Serializes a TestExtensionOrderings2 to protobuf.
+   * Serializes TestExtensionOrderings2 to protobuf.
    */
   encode: function (msg: Partial<TestExtensionOrderings2>): Uint8Array {
     return TestExtensionOrderings2._writeMessage(
@@ -106237,7 +106237,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from protobuf.
+   * Deserializes TestExtensionOrderings2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionOrderings2 {
     return TestExtensionOrderings2._readMessage(
@@ -106247,14 +106247,14 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Serializes a TestExtensionOrderings2 to JSON.
+   * Serializes TestExtensionOrderings2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionOrderings2>): string {
     return JSON.stringify(TestExtensionOrderings2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionOrderings2 from JSON.
+   * Deserializes TestExtensionOrderings2 from JSON.
    */
   decodeJSON: function (json: string): TestExtensionOrderings2 {
     return TestExtensionOrderings2._readMessageJSON(
@@ -106264,7 +106264,7 @@ export const TestExtensionOrderings2 = {
   },
 
   /**
-   * Initializes a TestExtensionOrderings2 with all fields set to their default value.
+   * Initializes TestExtensionOrderings2 with all fields set to their default value.
    */
   initialize: function (): TestExtensionOrderings2 {
     return {
@@ -106337,7 +106337,7 @@ export const TestExtensionOrderings2 = {
 
   TestExtensionOrderings3: {
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to protobuf.
      */
     encode: function (
       msg: Partial<TestExtensionOrderings2.TestExtensionOrderings3>
@@ -106349,7 +106349,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -106361,7 +106361,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Serializes a TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
+     * Serializes TestExtensionOrderings2.TestExtensionOrderings3 to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestExtensionOrderings2.TestExtensionOrderings3>
@@ -106372,7 +106372,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Deserializes a TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
+     * Deserializes TestExtensionOrderings2.TestExtensionOrderings3 from JSON.
      */
     decodeJSON: function (
       json: string
@@ -106384,7 +106384,7 @@ export const TestExtensionOrderings2 = {
     },
 
     /**
-     * Initializes a TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
+     * Initializes TestExtensionOrderings2.TestExtensionOrderings3 with all fields set to their default value.
      */
     initialize: function (): TestExtensionOrderings2.TestExtensionOrderings3 {
       return {
@@ -106459,7 +106459,7 @@ export const TestExtensionOrderings2 = {
 
 export const TestExtremeDefaultValues = {
   /**
-   * Serializes a TestExtremeDefaultValues to protobuf.
+   * Serializes TestExtremeDefaultValues to protobuf.
    */
   encode: function (msg: Partial<TestExtremeDefaultValues>): Uint8Array {
     return TestExtremeDefaultValues._writeMessage(
@@ -106469,7 +106469,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from protobuf.
+   * Deserializes TestExtremeDefaultValues from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtremeDefaultValues {
     return TestExtremeDefaultValues._readMessage(
@@ -106479,14 +106479,14 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Serializes a TestExtremeDefaultValues to JSON.
+   * Serializes TestExtremeDefaultValues to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtremeDefaultValues>): string {
     return JSON.stringify(TestExtremeDefaultValues._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtremeDefaultValues from JSON.
+   * Deserializes TestExtremeDefaultValues from JSON.
    */
   decodeJSON: function (json: string): TestExtremeDefaultValues {
     return TestExtremeDefaultValues._readMessageJSON(
@@ -106496,7 +106496,7 @@ export const TestExtremeDefaultValues = {
   },
 
   /**
-   * Initializes a TestExtremeDefaultValues with all fields set to their default value.
+   * Initializes TestExtremeDefaultValues with all fields set to their default value.
    */
   initialize: function (): TestExtremeDefaultValues {
     return {
@@ -106963,7 +106963,7 @@ export const TestExtremeDefaultValues = {
 
 export const SparseEnumMessage = {
   /**
-   * Serializes a SparseEnumMessage to protobuf.
+   * Serializes SparseEnumMessage to protobuf.
    */
   encode: function (msg: Partial<SparseEnumMessage>): Uint8Array {
     return SparseEnumMessage._writeMessage(
@@ -106973,7 +106973,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Deserializes a SparseEnumMessage from protobuf.
+   * Deserializes SparseEnumMessage from protobuf.
    */
   decode: function (bytes: ByteSource): SparseEnumMessage {
     return SparseEnumMessage._readMessage(
@@ -106983,14 +106983,14 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Serializes a SparseEnumMessage to JSON.
+   * Serializes SparseEnumMessage to JSON.
    */
   encodeJSON: function (msg: Partial<SparseEnumMessage>): string {
     return JSON.stringify(SparseEnumMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SparseEnumMessage from JSON.
+   * Deserializes SparseEnumMessage from JSON.
    */
   decodeJSON: function (json: string): SparseEnumMessage {
     return SparseEnumMessage._readMessageJSON(
@@ -107000,7 +107000,7 @@ export const SparseEnumMessage = {
   },
 
   /**
-   * Initializes a SparseEnumMessage with all fields set to their default value.
+   * Initializes SparseEnumMessage with all fields set to their default value.
    */
   initialize: function (): SparseEnumMessage {
     return {
@@ -107074,14 +107074,14 @@ export const SparseEnumMessage = {
 
 export const OneString = {
   /**
-   * Serializes a OneString to protobuf.
+   * Serializes OneString to protobuf.
    */
   encode: function (msg: Partial<OneString>): Uint8Array {
     return OneString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneString from protobuf.
+   * Deserializes OneString from protobuf.
    */
   decode: function (bytes: ByteSource): OneString {
     return OneString._readMessage(
@@ -107091,21 +107091,21 @@ export const OneString = {
   },
 
   /**
-   * Serializes a OneString to JSON.
+   * Serializes OneString to JSON.
    */
   encodeJSON: function (msg: Partial<OneString>): string {
     return JSON.stringify(OneString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneString from JSON.
+   * Deserializes OneString from JSON.
    */
   decodeJSON: function (json: string): OneString {
     return OneString._readMessageJSON(OneString.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneString with all fields set to their default value.
+   * Initializes OneString with all fields set to their default value.
    */
   initialize: function (): OneString {
     return {
@@ -107173,14 +107173,14 @@ export const OneString = {
 
 export const MoreString = {
   /**
-   * Serializes a MoreString to protobuf.
+   * Serializes MoreString to protobuf.
    */
   encode: function (msg: Partial<MoreString>): Uint8Array {
     return MoreString._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreString from protobuf.
+   * Deserializes MoreString from protobuf.
    */
   decode: function (bytes: ByteSource): MoreString {
     return MoreString._readMessage(
@@ -107190,14 +107190,14 @@ export const MoreString = {
   },
 
   /**
-   * Serializes a MoreString to JSON.
+   * Serializes MoreString to JSON.
    */
   encodeJSON: function (msg: Partial<MoreString>): string {
     return JSON.stringify(MoreString._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreString from JSON.
+   * Deserializes MoreString from JSON.
    */
   decodeJSON: function (json: string): MoreString {
     return MoreString._readMessageJSON(
@@ -107207,7 +107207,7 @@ export const MoreString = {
   },
 
   /**
-   * Initializes a MoreString with all fields set to their default value.
+   * Initializes MoreString with all fields set to their default value.
    */
   initialize: function (): MoreString {
     return {
@@ -107275,14 +107275,14 @@ export const MoreString = {
 
 export const OneBytes = {
   /**
-   * Serializes a OneBytes to protobuf.
+   * Serializes OneBytes to protobuf.
    */
   encode: function (msg: Partial<OneBytes>): Uint8Array {
     return OneBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a OneBytes from protobuf.
+   * Deserializes OneBytes from protobuf.
    */
   decode: function (bytes: ByteSource): OneBytes {
     return OneBytes._readMessage(
@@ -107292,21 +107292,21 @@ export const OneBytes = {
   },
 
   /**
-   * Serializes a OneBytes to JSON.
+   * Serializes OneBytes to JSON.
    */
   encodeJSON: function (msg: Partial<OneBytes>): string {
     return JSON.stringify(OneBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneBytes from JSON.
+   * Deserializes OneBytes from JSON.
    */
   decodeJSON: function (json: string): OneBytes {
     return OneBytes._readMessageJSON(OneBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a OneBytes with all fields set to their default value.
+   * Initializes OneBytes with all fields set to their default value.
    */
   initialize: function (): OneBytes {
     return {
@@ -107374,14 +107374,14 @@ export const OneBytes = {
 
 export const MoreBytes = {
   /**
-   * Serializes a MoreBytes to protobuf.
+   * Serializes MoreBytes to protobuf.
    */
   encode: function (msg: Partial<MoreBytes>): Uint8Array {
     return MoreBytes._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a MoreBytes from protobuf.
+   * Deserializes MoreBytes from protobuf.
    */
   decode: function (bytes: ByteSource): MoreBytes {
     return MoreBytes._readMessage(
@@ -107391,21 +107391,21 @@ export const MoreBytes = {
   },
 
   /**
-   * Serializes a MoreBytes to JSON.
+   * Serializes MoreBytes to JSON.
    */
   encodeJSON: function (msg: Partial<MoreBytes>): string {
     return JSON.stringify(MoreBytes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MoreBytes from JSON.
+   * Deserializes MoreBytes from JSON.
    */
   decodeJSON: function (json: string): MoreBytes {
     return MoreBytes._readMessageJSON(MoreBytes.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a MoreBytes with all fields set to their default value.
+   * Initializes MoreBytes with all fields set to their default value.
    */
   initialize: function (): MoreBytes {
     return {
@@ -107473,7 +107473,7 @@ export const MoreBytes = {
 
 export const Int32Message = {
   /**
-   * Serializes a Int32Message to protobuf.
+   * Serializes Int32Message to protobuf.
    */
   encode: function (msg: Partial<Int32Message>): Uint8Array {
     return Int32Message._writeMessage(
@@ -107483,7 +107483,7 @@ export const Int32Message = {
   },
 
   /**
-   * Deserializes a Int32Message from protobuf.
+   * Deserializes Int32Message from protobuf.
    */
   decode: function (bytes: ByteSource): Int32Message {
     return Int32Message._readMessage(
@@ -107493,14 +107493,14 @@ export const Int32Message = {
   },
 
   /**
-   * Serializes a Int32Message to JSON.
+   * Serializes Int32Message to JSON.
    */
   encodeJSON: function (msg: Partial<Int32Message>): string {
     return JSON.stringify(Int32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Message from JSON.
+   * Deserializes Int32Message from JSON.
    */
   decodeJSON: function (json: string): Int32Message {
     return Int32Message._readMessageJSON(
@@ -107510,7 +107510,7 @@ export const Int32Message = {
   },
 
   /**
-   * Initializes a Int32Message with all fields set to their default value.
+   * Initializes Int32Message with all fields set to their default value.
    */
   initialize: function (): Int32Message {
     return {
@@ -107581,7 +107581,7 @@ export const Int32Message = {
 
 export const Uint32Message = {
   /**
-   * Serializes a Uint32Message to protobuf.
+   * Serializes Uint32Message to protobuf.
    */
   encode: function (msg: Partial<Uint32Message>): Uint8Array {
     return Uint32Message._writeMessage(
@@ -107591,7 +107591,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Deserializes a Uint32Message from protobuf.
+   * Deserializes Uint32Message from protobuf.
    */
   decode: function (bytes: ByteSource): Uint32Message {
     return Uint32Message._readMessage(
@@ -107601,14 +107601,14 @@ export const Uint32Message = {
   },
 
   /**
-   * Serializes a Uint32Message to JSON.
+   * Serializes Uint32Message to JSON.
    */
   encodeJSON: function (msg: Partial<Uint32Message>): string {
     return JSON.stringify(Uint32Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint32Message from JSON.
+   * Deserializes Uint32Message from JSON.
    */
   decodeJSON: function (json: string): Uint32Message {
     return Uint32Message._readMessageJSON(
@@ -107618,7 +107618,7 @@ export const Uint32Message = {
   },
 
   /**
-   * Initializes a Uint32Message with all fields set to their default value.
+   * Initializes Uint32Message with all fields set to their default value.
    */
   initialize: function (): Uint32Message {
     return {
@@ -107689,7 +107689,7 @@ export const Uint32Message = {
 
 export const Int64Message = {
   /**
-   * Serializes a Int64Message to protobuf.
+   * Serializes Int64Message to protobuf.
    */
   encode: function (msg: Partial<Int64Message>): Uint8Array {
     return Int64Message._writeMessage(
@@ -107699,7 +107699,7 @@ export const Int64Message = {
   },
 
   /**
-   * Deserializes a Int64Message from protobuf.
+   * Deserializes Int64Message from protobuf.
    */
   decode: function (bytes: ByteSource): Int64Message {
     return Int64Message._readMessage(
@@ -107709,14 +107709,14 @@ export const Int64Message = {
   },
 
   /**
-   * Serializes a Int64Message to JSON.
+   * Serializes Int64Message to JSON.
    */
   encodeJSON: function (msg: Partial<Int64Message>): string {
     return JSON.stringify(Int64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Message from JSON.
+   * Deserializes Int64Message from JSON.
    */
   decodeJSON: function (json: string): Int64Message {
     return Int64Message._readMessageJSON(
@@ -107726,7 +107726,7 @@ export const Int64Message = {
   },
 
   /**
-   * Initializes a Int64Message with all fields set to their default value.
+   * Initializes Int64Message with all fields set to their default value.
    */
   initialize: function (): Int64Message {
     return {
@@ -107797,7 +107797,7 @@ export const Int64Message = {
 
 export const Uint64Message = {
   /**
-   * Serializes a Uint64Message to protobuf.
+   * Serializes Uint64Message to protobuf.
    */
   encode: function (msg: Partial<Uint64Message>): Uint8Array {
     return Uint64Message._writeMessage(
@@ -107807,7 +107807,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Deserializes a Uint64Message from protobuf.
+   * Deserializes Uint64Message from protobuf.
    */
   decode: function (bytes: ByteSource): Uint64Message {
     return Uint64Message._readMessage(
@@ -107817,14 +107817,14 @@ export const Uint64Message = {
   },
 
   /**
-   * Serializes a Uint64Message to JSON.
+   * Serializes Uint64Message to JSON.
    */
   encodeJSON: function (msg: Partial<Uint64Message>): string {
     return JSON.stringify(Uint64Message._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Uint64Message from JSON.
+   * Deserializes Uint64Message from JSON.
    */
   decodeJSON: function (json: string): Uint64Message {
     return Uint64Message._readMessageJSON(
@@ -107834,7 +107834,7 @@ export const Uint64Message = {
   },
 
   /**
-   * Initializes a Uint64Message with all fields set to their default value.
+   * Initializes Uint64Message with all fields set to their default value.
    */
   initialize: function (): Uint64Message {
     return {
@@ -107905,14 +107905,14 @@ export const Uint64Message = {
 
 export const BoolMessage = {
   /**
-   * Serializes a BoolMessage to protobuf.
+   * Serializes BoolMessage to protobuf.
    */
   encode: function (msg: Partial<BoolMessage>): Uint8Array {
     return BoolMessage._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolMessage from protobuf.
+   * Deserializes BoolMessage from protobuf.
    */
   decode: function (bytes: ByteSource): BoolMessage {
     return BoolMessage._readMessage(
@@ -107922,14 +107922,14 @@ export const BoolMessage = {
   },
 
   /**
-   * Serializes a BoolMessage to JSON.
+   * Serializes BoolMessage to JSON.
    */
   encodeJSON: function (msg: Partial<BoolMessage>): string {
     return JSON.stringify(BoolMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolMessage from JSON.
+   * Deserializes BoolMessage from JSON.
    */
   decodeJSON: function (json: string): BoolMessage {
     return BoolMessage._readMessageJSON(
@@ -107939,7 +107939,7 @@ export const BoolMessage = {
   },
 
   /**
-   * Initializes a BoolMessage with all fields set to their default value.
+   * Initializes BoolMessage with all fields set to their default value.
    */
   initialize: function (): BoolMessage {
     return {
@@ -108007,14 +108007,14 @@ export const BoolMessage = {
 
 export const TestOneof = {
   /**
-   * Serializes a TestOneof to protobuf.
+   * Serializes TestOneof to protobuf.
    */
   encode: function (msg: Partial<TestOneof>): Uint8Array {
     return TestOneof._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof from protobuf.
+   * Deserializes TestOneof from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof {
     return TestOneof._readMessage(
@@ -108024,21 +108024,21 @@ export const TestOneof = {
   },
 
   /**
-   * Serializes a TestOneof to JSON.
+   * Serializes TestOneof to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof>): string {
     return JSON.stringify(TestOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof from JSON.
+   * Deserializes TestOneof from JSON.
    */
   decodeJSON: function (json: string): TestOneof {
     return TestOneof._readMessageJSON(TestOneof.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestOneof with all fields set to their default value.
+   * Initializes TestOneof with all fields set to their default value.
    */
   initialize: function (): TestOneof {
     return {
@@ -108138,7 +108138,7 @@ export const TestOneof = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof.FooGroup to protobuf.
+     * Serializes TestOneof.FooGroup to protobuf.
      */
     encode: function (msg: Partial<TestOneof.FooGroup>): Uint8Array {
       return TestOneof.FooGroup._writeMessage(
@@ -108148,7 +108148,7 @@ export const TestOneof = {
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from protobuf.
+     * Deserializes TestOneof.FooGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof.FooGroup {
       return TestOneof.FooGroup._readMessage(
@@ -108158,14 +108158,14 @@ export const TestOneof = {
     },
 
     /**
-     * Serializes a TestOneof.FooGroup to JSON.
+     * Serializes TestOneof.FooGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof.FooGroup>): string {
       return JSON.stringify(TestOneof.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof.FooGroup from JSON.
+     * Deserializes TestOneof.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneof.FooGroup {
       return TestOneof.FooGroup._readMessageJSON(
@@ -108175,7 +108175,7 @@ export const TestOneof = {
     },
 
     /**
-     * Initializes a TestOneof.FooGroup with all fields set to their default value.
+     * Initializes TestOneof.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneof.FooGroup {
       return {
@@ -108265,7 +108265,7 @@ export const TestOneof = {
 
 export const TestOneofBackwardsCompatible = {
   /**
-   * Serializes a TestOneofBackwardsCompatible to protobuf.
+   * Serializes TestOneofBackwardsCompatible to protobuf.
    */
   encode: function (msg: Partial<TestOneofBackwardsCompatible>): Uint8Array {
     return TestOneofBackwardsCompatible._writeMessage(
@@ -108275,7 +108275,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from protobuf.
+   * Deserializes TestOneofBackwardsCompatible from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneofBackwardsCompatible {
     return TestOneofBackwardsCompatible._readMessage(
@@ -108285,14 +108285,14 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Serializes a TestOneofBackwardsCompatible to JSON.
+   * Serializes TestOneofBackwardsCompatible to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneofBackwardsCompatible>): string {
     return JSON.stringify(TestOneofBackwardsCompatible._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneofBackwardsCompatible from JSON.
+   * Deserializes TestOneofBackwardsCompatible from JSON.
    */
   decodeJSON: function (json: string): TestOneofBackwardsCompatible {
     return TestOneofBackwardsCompatible._readMessageJSON(
@@ -108302,7 +108302,7 @@ export const TestOneofBackwardsCompatible = {
   },
 
   /**
-   * Initializes a TestOneofBackwardsCompatible with all fields set to their default value.
+   * Initializes TestOneofBackwardsCompatible with all fields set to their default value.
    */
   initialize: function (): TestOneofBackwardsCompatible {
     return {
@@ -108410,7 +108410,7 @@ export const TestOneofBackwardsCompatible = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to protobuf.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestOneofBackwardsCompatible.FooGroup>
@@ -108422,7 +108422,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from protobuf.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -108434,7 +108434,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Serializes a TestOneofBackwardsCompatible.FooGroup to JSON.
+     * Serializes TestOneofBackwardsCompatible.FooGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestOneofBackwardsCompatible.FooGroup>
@@ -108445,7 +108445,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Deserializes a TestOneofBackwardsCompatible.FooGroup from JSON.
+     * Deserializes TestOneofBackwardsCompatible.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneofBackwardsCompatible.FooGroup {
       return TestOneofBackwardsCompatible.FooGroup._readMessageJSON(
@@ -108455,7 +108455,7 @@ export const TestOneofBackwardsCompatible = {
     },
 
     /**
-     * Initializes a TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
+     * Initializes TestOneofBackwardsCompatible.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneofBackwardsCompatible.FooGroup {
       return {
@@ -108545,14 +108545,14 @@ export const TestOneofBackwardsCompatible = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg: Partial<TestOneof2>): Uint8Array {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof2 {
     return TestOneof2._readMessage(
@@ -108562,14 +108562,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof2>): string {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json: string): TestOneof2 {
     return TestOneof2._readMessageJSON(
@@ -108579,7 +108579,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function (): TestOneof2 {
     return {
@@ -108998,7 +108998,7 @@ export const TestOneof2 = {
 
   FooGroup: {
     /**
-     * Serializes a TestOneof2.FooGroup to protobuf.
+     * Serializes TestOneof2.FooGroup to protobuf.
      */
     encode: function (msg: Partial<TestOneof2.FooGroup>): Uint8Array {
       return TestOneof2.FooGroup._writeMessage(
@@ -109008,7 +109008,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from protobuf.
+     * Deserializes TestOneof2.FooGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof2.FooGroup {
       return TestOneof2.FooGroup._readMessage(
@@ -109018,14 +109018,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.FooGroup to JSON.
+     * Serializes TestOneof2.FooGroup to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof2.FooGroup>): string {
       return JSON.stringify(TestOneof2.FooGroup._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.FooGroup from JSON.
+     * Deserializes TestOneof2.FooGroup from JSON.
      */
     decodeJSON: function (json: string): TestOneof2.FooGroup {
       return TestOneof2.FooGroup._readMessageJSON(
@@ -109035,7 +109035,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.FooGroup with all fields set to their default value.
+     * Initializes TestOneof2.FooGroup with all fields set to their default value.
      */
     initialize: function (): TestOneof2.FooGroup {
       return {
@@ -109124,7 +109124,7 @@ export const TestOneof2 = {
 
   NestedMessage: {
     /**
-     * Serializes a TestOneof2.NestedMessage to protobuf.
+     * Serializes TestOneof2.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestOneof2.NestedMessage>): Uint8Array {
       return TestOneof2.NestedMessage._writeMessage(
@@ -109134,7 +109134,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from protobuf.
+     * Deserializes TestOneof2.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestOneof2.NestedMessage {
       return TestOneof2.NestedMessage._readMessage(
@@ -109144,14 +109144,14 @@ export const TestOneof2 = {
     },
 
     /**
-     * Serializes a TestOneof2.NestedMessage to JSON.
+     * Serializes TestOneof2.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestOneof2.NestedMessage>): string {
       return JSON.stringify(TestOneof2.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestOneof2.NestedMessage from JSON.
+     * Deserializes TestOneof2.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestOneof2.NestedMessage {
       return TestOneof2.NestedMessage._readMessageJSON(
@@ -109161,7 +109161,7 @@ export const TestOneof2 = {
     },
 
     /**
-     * Initializes a TestOneof2.NestedMessage with all fields set to their default value.
+     * Initializes TestOneof2.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestOneof2.NestedMessage {
       return {
@@ -109251,7 +109251,7 @@ export const TestOneof2 = {
 
 export const TestRequiredOneof = {
   /**
-   * Serializes a TestRequiredOneof to protobuf.
+   * Serializes TestRequiredOneof to protobuf.
    */
   encode: function (msg: Partial<TestRequiredOneof>): Uint8Array {
     return TestRequiredOneof._writeMessage(
@@ -109261,7 +109261,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Deserializes a TestRequiredOneof from protobuf.
+   * Deserializes TestRequiredOneof from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredOneof {
     return TestRequiredOneof._readMessage(
@@ -109271,14 +109271,14 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Serializes a TestRequiredOneof to JSON.
+   * Serializes TestRequiredOneof to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredOneof>): string {
     return JSON.stringify(TestRequiredOneof._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredOneof from JSON.
+   * Deserializes TestRequiredOneof from JSON.
    */
   decodeJSON: function (json: string): TestRequiredOneof {
     return TestRequiredOneof._readMessageJSON(
@@ -109288,7 +109288,7 @@ export const TestRequiredOneof = {
   },
 
   /**
-   * Initializes a TestRequiredOneof with all fields set to their default value.
+   * Initializes TestRequiredOneof with all fields set to their default value.
    */
   initialize: function (): TestRequiredOneof {
     return {
@@ -109403,7 +109403,7 @@ export const TestRequiredOneof = {
 
   NestedMessage: {
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to protobuf.
+     * Serializes TestRequiredOneof.NestedMessage to protobuf.
      */
     encode: function (
       msg: Partial<TestRequiredOneof.NestedMessage>
@@ -109415,7 +109415,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from protobuf.
+     * Deserializes TestRequiredOneof.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestRequiredOneof.NestedMessage {
       return TestRequiredOneof.NestedMessage._readMessage(
@@ -109425,7 +109425,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Serializes a TestRequiredOneof.NestedMessage to JSON.
+     * Serializes TestRequiredOneof.NestedMessage to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestRequiredOneof.NestedMessage>
@@ -109436,7 +109436,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Deserializes a TestRequiredOneof.NestedMessage from JSON.
+     * Deserializes TestRequiredOneof.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestRequiredOneof.NestedMessage {
       return TestRequiredOneof.NestedMessage._readMessageJSON(
@@ -109446,7 +109446,7 @@ export const TestRequiredOneof = {
     },
 
     /**
-     * Initializes a TestRequiredOneof.NestedMessage with all fields set to their default value.
+     * Initializes TestRequiredOneof.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestRequiredOneof.NestedMessage {
       return {
@@ -109521,7 +109521,7 @@ export const TestRequiredOneof = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestPackedTypes>): Uint8Array {
     return TestPackedTypes._writeMessage(
@@ -109531,7 +109531,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestPackedTypes {
     return TestPackedTypes._readMessage(
@@ -109541,14 +109541,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestPackedTypes>): string {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestPackedTypes {
     return TestPackedTypes._readMessageJSON(
@@ -109558,7 +109558,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function (): TestPackedTypes {
     return {
@@ -109842,7 +109842,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestUnpackedTypes>): Uint8Array {
     return TestUnpackedTypes._writeMessage(
@@ -109852,7 +109852,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestUnpackedTypes {
     return TestUnpackedTypes._readMessage(
@@ -109862,14 +109862,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestUnpackedTypes>): string {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestUnpackedTypes {
     return TestUnpackedTypes._readMessageJSON(
@@ -109879,7 +109879,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function (): TestUnpackedTypes {
     return {
@@ -110163,35 +110163,35 @@ export const TestUnpackedTypes = {
 
 export const TestPackedExtensions = {
   /**
-   * Serializes a TestPackedExtensions to protobuf.
+   * Serializes TestPackedExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestPackedExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestPackedExtensions from protobuf.
+   * Deserializes TestPackedExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestPackedExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestPackedExtensions to JSON.
+   * Serializes TestPackedExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestPackedExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestPackedExtensions from JSON.
+   * Deserializes TestPackedExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestPackedExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestPackedExtensions with all fields set to their default value.
+   * Initializes TestPackedExtensions with all fields set to their default value.
    */
   initialize: function (): TestPackedExtensions {
     return {};
@@ -110239,35 +110239,35 @@ export const TestPackedExtensions = {
 
 export const TestUnpackedExtensions = {
   /**
-   * Serializes a TestUnpackedExtensions to protobuf.
+   * Serializes TestUnpackedExtensions to protobuf.
    */
   encode: function (_msg?: Partial<TestUnpackedExtensions>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from protobuf.
+   * Deserializes TestUnpackedExtensions from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestUnpackedExtensions {
     return {};
   },
 
   /**
-   * Serializes a TestUnpackedExtensions to JSON.
+   * Serializes TestUnpackedExtensions to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestUnpackedExtensions>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestUnpackedExtensions from JSON.
+   * Deserializes TestUnpackedExtensions from JSON.
    */
   decodeJSON: function (_json?: string): TestUnpackedExtensions {
     return {};
   },
 
   /**
-   * Initializes a TestUnpackedExtensions with all fields set to their default value.
+   * Initializes TestUnpackedExtensions with all fields set to their default value.
    */
   initialize: function (): TestUnpackedExtensions {
     return {};
@@ -110315,7 +110315,7 @@ export const TestUnpackedExtensions = {
 
 export const TestDynamicExtensions = {
   /**
-   * Serializes a TestDynamicExtensions to protobuf.
+   * Serializes TestDynamicExtensions to protobuf.
    */
   encode: function (msg: Partial<TestDynamicExtensions>): Uint8Array {
     return TestDynamicExtensions._writeMessage(
@@ -110325,7 +110325,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from protobuf.
+   * Deserializes TestDynamicExtensions from protobuf.
    */
   decode: function (bytes: ByteSource): TestDynamicExtensions {
     return TestDynamicExtensions._readMessage(
@@ -110335,14 +110335,14 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Serializes a TestDynamicExtensions to JSON.
+   * Serializes TestDynamicExtensions to JSON.
    */
   encodeJSON: function (msg: Partial<TestDynamicExtensions>): string {
     return JSON.stringify(TestDynamicExtensions._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestDynamicExtensions from JSON.
+   * Deserializes TestDynamicExtensions from JSON.
    */
   decodeJSON: function (json: string): TestDynamicExtensions {
     return TestDynamicExtensions._readMessageJSON(
@@ -110352,7 +110352,7 @@ export const TestDynamicExtensions = {
   },
 
   /**
-   * Initializes a TestDynamicExtensions with all fields set to their default value.
+   * Initializes TestDynamicExtensions with all fields set to their default value.
    */
   initialize: function (): TestDynamicExtensions {
     return {
@@ -110604,7 +110604,7 @@ export const TestDynamicExtensions = {
 
   DynamicMessageType: {
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to protobuf.
+     * Serializes TestDynamicExtensions.DynamicMessageType to protobuf.
      */
     encode: function (
       msg: Partial<TestDynamicExtensions.DynamicMessageType>
@@ -110616,7 +110616,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from protobuf.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -110628,7 +110628,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Serializes a TestDynamicExtensions.DynamicMessageType to JSON.
+     * Serializes TestDynamicExtensions.DynamicMessageType to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestDynamicExtensions.DynamicMessageType>
@@ -110639,7 +110639,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Deserializes a TestDynamicExtensions.DynamicMessageType from JSON.
+     * Deserializes TestDynamicExtensions.DynamicMessageType from JSON.
      */
     decodeJSON: function (
       json: string
@@ -110651,7 +110651,7 @@ export const TestDynamicExtensions = {
     },
 
     /**
-     * Initializes a TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
+     * Initializes TestDynamicExtensions.DynamicMessageType with all fields set to their default value.
      */
     initialize: function (): TestDynamicExtensions.DynamicMessageType {
       return {
@@ -110726,7 +110726,7 @@ export const TestDynamicExtensions = {
 
 export const TestRepeatedScalarDifferentTagSizes = {
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to protobuf.
+   * Serializes TestRepeatedScalarDifferentTagSizes to protobuf.
    */
   encode: function (
     msg: Partial<TestRepeatedScalarDifferentTagSizes>
@@ -110738,7 +110738,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from protobuf.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from protobuf.
    */
   decode: function (bytes: ByteSource): TestRepeatedScalarDifferentTagSizes {
     return TestRepeatedScalarDifferentTagSizes._readMessage(
@@ -110748,7 +110748,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Serializes a TestRepeatedScalarDifferentTagSizes to JSON.
+   * Serializes TestRepeatedScalarDifferentTagSizes to JSON.
    */
   encodeJSON: function (
     msg: Partial<TestRepeatedScalarDifferentTagSizes>
@@ -110759,7 +110759,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Deserializes a TestRepeatedScalarDifferentTagSizes from JSON.
+   * Deserializes TestRepeatedScalarDifferentTagSizes from JSON.
    */
   decodeJSON: function (json: string): TestRepeatedScalarDifferentTagSizes {
     return TestRepeatedScalarDifferentTagSizes._readMessageJSON(
@@ -110769,7 +110769,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
   },
 
   /**
-   * Initializes a TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
+   * Initializes TestRepeatedScalarDifferentTagSizes with all fields set to their default value.
    */
   initialize: function (): TestRepeatedScalarDifferentTagSizes {
     return {
@@ -110927,7 +110927,7 @@ export const TestRepeatedScalarDifferentTagSizes = {
 
 export const TestParsingMerge = {
   /**
-   * Serializes a TestParsingMerge to protobuf.
+   * Serializes TestParsingMerge to protobuf.
    */
   encode: function (msg: Partial<TestParsingMerge>): Uint8Array {
     return TestParsingMerge._writeMessage(
@@ -110937,7 +110937,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Deserializes a TestParsingMerge from protobuf.
+   * Deserializes TestParsingMerge from protobuf.
    */
   decode: function (bytes: ByteSource): TestParsingMerge {
     return TestParsingMerge._readMessage(
@@ -110947,14 +110947,14 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Serializes a TestParsingMerge to JSON.
+   * Serializes TestParsingMerge to JSON.
    */
   encodeJSON: function (msg: Partial<TestParsingMerge>): string {
     return JSON.stringify(TestParsingMerge._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestParsingMerge from JSON.
+   * Deserializes TestParsingMerge from JSON.
    */
   decodeJSON: function (json: string): TestParsingMerge {
     return TestParsingMerge._readMessageJSON(
@@ -110964,7 +110964,7 @@ export const TestParsingMerge = {
   },
 
   /**
-   * Initializes a TestParsingMerge with all fields set to their default value.
+   * Initializes TestParsingMerge with all fields set to their default value.
    */
   initialize: function (): TestParsingMerge {
     return {
@@ -111093,7 +111093,7 @@ export const TestParsingMerge = {
 
   RepeatedFieldsGenerator: {
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to protobuf.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.RepeatedFieldsGenerator>
@@ -111105,7 +111105,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from protobuf.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from protobuf.
      */
     decode: function (
       bytes: ByteSource
@@ -111117,7 +111117,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedFieldsGenerator to JSON.
+     * Serializes TestParsingMerge.RepeatedFieldsGenerator to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.RepeatedFieldsGenerator>
@@ -111128,7 +111128,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedFieldsGenerator from JSON.
+     * Deserializes TestParsingMerge.RepeatedFieldsGenerator from JSON.
      */
     decodeJSON: function (
       json: string
@@ -111140,7 +111140,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedFieldsGenerator with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.RepeatedFieldsGenerator {
       return {
@@ -111323,7 +111323,7 @@ export const TestParsingMerge = {
 
     Group1: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to protobuf.
        */
       encode: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group1>
@@ -111335,7 +111335,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -111347,7 +111347,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group1 to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group1>
@@ -111358,7 +111358,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group1 from JSON.
        */
       decodeJSON: function (
         json: string
@@ -111370,7 +111370,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group1 with all fields set to their default value.
        */
       initialize: function (): TestParsingMerge.RepeatedFieldsGenerator.Group1 {
         return {
@@ -111449,7 +111449,7 @@ export const TestParsingMerge = {
 
     Group2: {
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to protobuf.
        */
       encode: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group2>
@@ -111461,7 +111461,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from protobuf.
        */
       decode: function (
         bytes: ByteSource
@@ -111473,7 +111473,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Serializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
+       * Serializes TestParsingMerge.RepeatedFieldsGenerator.Group2 to JSON.
        */
       encodeJSON: function (
         msg: Partial<TestParsingMerge.RepeatedFieldsGenerator.Group2>
@@ -111484,7 +111484,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Deserializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
+       * Deserializes TestParsingMerge.RepeatedFieldsGenerator.Group2 from JSON.
        */
       decodeJSON: function (
         json: string
@@ -111496,7 +111496,7 @@ export const TestParsingMerge = {
       },
 
       /**
-       * Initializes a TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
+       * Initializes TestParsingMerge.RepeatedFieldsGenerator.Group2 with all fields set to their default value.
        */
       initialize: function (): TestParsingMerge.RepeatedFieldsGenerator.Group2 {
         return {
@@ -111576,7 +111576,7 @@ export const TestParsingMerge = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to protobuf.
+     * Serializes TestParsingMerge.OptionalGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.OptionalGroup>
@@ -111588,7 +111588,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from protobuf.
+     * Deserializes TestParsingMerge.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestParsingMerge.OptionalGroup {
       return TestParsingMerge.OptionalGroup._readMessage(
@@ -111598,7 +111598,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.OptionalGroup to JSON.
+     * Serializes TestParsingMerge.OptionalGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.OptionalGroup>
@@ -111609,7 +111609,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.OptionalGroup from JSON.
+     * Deserializes TestParsingMerge.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestParsingMerge.OptionalGroup {
       return TestParsingMerge.OptionalGroup._readMessageJSON(
@@ -111619,7 +111619,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.OptionalGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.OptionalGroup {
       return {
@@ -111708,7 +111708,7 @@ export const TestParsingMerge = {
 
   RepeatedGroup: {
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to protobuf.
+     * Serializes TestParsingMerge.RepeatedGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestParsingMerge.RepeatedGroup>
@@ -111720,7 +111720,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from protobuf.
+     * Deserializes TestParsingMerge.RepeatedGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestParsingMerge.RepeatedGroup {
       return TestParsingMerge.RepeatedGroup._readMessage(
@@ -111730,7 +111730,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Serializes a TestParsingMerge.RepeatedGroup to JSON.
+     * Serializes TestParsingMerge.RepeatedGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestParsingMerge.RepeatedGroup>
@@ -111741,7 +111741,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Deserializes a TestParsingMerge.RepeatedGroup from JSON.
+     * Deserializes TestParsingMerge.RepeatedGroup from JSON.
      */
     decodeJSON: function (json: string): TestParsingMerge.RepeatedGroup {
       return TestParsingMerge.RepeatedGroup._readMessageJSON(
@@ -111751,7 +111751,7 @@ export const TestParsingMerge = {
     },
 
     /**
-     * Initializes a TestParsingMerge.RepeatedGroup with all fields set to their default value.
+     * Initializes TestParsingMerge.RepeatedGroup with all fields set to their default value.
      */
     initialize: function (): TestParsingMerge.RepeatedGroup {
       return {
@@ -111841,7 +111841,7 @@ export const TestParsingMerge = {
 
 export const TestCommentInjectionMessage = {
   /**
-   * Serializes a TestCommentInjectionMessage to protobuf.
+   * Serializes TestCommentInjectionMessage to protobuf.
    */
   encode: function (msg: Partial<TestCommentInjectionMessage>): Uint8Array {
     return TestCommentInjectionMessage._writeMessage(
@@ -111851,7 +111851,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from protobuf.
+   * Deserializes TestCommentInjectionMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestCommentInjectionMessage {
     return TestCommentInjectionMessage._readMessage(
@@ -111861,14 +111861,14 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Serializes a TestCommentInjectionMessage to JSON.
+   * Serializes TestCommentInjectionMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestCommentInjectionMessage>): string {
     return JSON.stringify(TestCommentInjectionMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestCommentInjectionMessage from JSON.
+   * Deserializes TestCommentInjectionMessage from JSON.
    */
   decodeJSON: function (json: string): TestCommentInjectionMessage {
     return TestCommentInjectionMessage._readMessageJSON(
@@ -111878,7 +111878,7 @@ export const TestCommentInjectionMessage = {
   },
 
   /**
-   * Initializes a TestCommentInjectionMessage with all fields set to their default value.
+   * Initializes TestCommentInjectionMessage with all fields set to their default value.
    */
   initialize: function (): TestCommentInjectionMessage {
     return {
@@ -111952,35 +111952,35 @@ export const TestCommentInjectionMessage = {
 
 export const FooRequest = {
   /**
-   * Serializes a FooRequest to protobuf.
+   * Serializes FooRequest to protobuf.
    */
   encode: function (_msg?: Partial<FooRequest>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooRequest from protobuf.
+   * Deserializes FooRequest from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooRequest {
     return {};
   },
 
   /**
-   * Serializes a FooRequest to JSON.
+   * Serializes FooRequest to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooRequest>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooRequest from JSON.
+   * Deserializes FooRequest from JSON.
    */
   decodeJSON: function (_json?: string): FooRequest {
     return {};
   },
 
   /**
-   * Initializes a FooRequest with all fields set to their default value.
+   * Initializes FooRequest with all fields set to their default value.
    */
   initialize: function (): FooRequest {
     return {};
@@ -112022,35 +112022,35 @@ export const FooRequest = {
 
 export const FooResponse = {
   /**
-   * Serializes a FooResponse to protobuf.
+   * Serializes FooResponse to protobuf.
    */
   encode: function (_msg?: Partial<FooResponse>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooResponse from protobuf.
+   * Deserializes FooResponse from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooResponse {
     return {};
   },
 
   /**
-   * Serializes a FooResponse to JSON.
+   * Serializes FooResponse to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooResponse>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooResponse from JSON.
+   * Deserializes FooResponse from JSON.
    */
   decodeJSON: function (_json?: string): FooResponse {
     return {};
   },
 
   /**
-   * Initializes a FooResponse with all fields set to their default value.
+   * Initializes FooResponse with all fields set to their default value.
    */
   initialize: function (): FooResponse {
     return {};
@@ -112095,35 +112095,35 @@ export const FooResponse = {
 
 export const FooClientMessage = {
   /**
-   * Serializes a FooClientMessage to protobuf.
+   * Serializes FooClientMessage to protobuf.
    */
   encode: function (_msg?: Partial<FooClientMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooClientMessage from protobuf.
+   * Deserializes FooClientMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooClientMessage {
     return {};
   },
 
   /**
-   * Serializes a FooClientMessage to JSON.
+   * Serializes FooClientMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooClientMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooClientMessage from JSON.
+   * Deserializes FooClientMessage from JSON.
    */
   decodeJSON: function (_json?: string): FooClientMessage {
     return {};
   },
 
   /**
-   * Initializes a FooClientMessage with all fields set to their default value.
+   * Initializes FooClientMessage with all fields set to their default value.
    */
   initialize: function (): FooClientMessage {
     return {};
@@ -112171,35 +112171,35 @@ export const FooClientMessage = {
 
 export const FooServerMessage = {
   /**
-   * Serializes a FooServerMessage to protobuf.
+   * Serializes FooServerMessage to protobuf.
    */
   encode: function (_msg?: Partial<FooServerMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a FooServerMessage from protobuf.
+   * Deserializes FooServerMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): FooServerMessage {
     return {};
   },
 
   /**
-   * Serializes a FooServerMessage to JSON.
+   * Serializes FooServerMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<FooServerMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a FooServerMessage from JSON.
+   * Deserializes FooServerMessage from JSON.
    */
   decodeJSON: function (_json?: string): FooServerMessage {
     return {};
   },
 
   /**
-   * Initializes a FooServerMessage with all fields set to their default value.
+   * Initializes FooServerMessage with all fields set to their default value.
    */
   initialize: function (): FooServerMessage {
     return {};
@@ -112247,35 +112247,35 @@ export const FooServerMessage = {
 
 export const BarRequest = {
   /**
-   * Serializes a BarRequest to protobuf.
+   * Serializes BarRequest to protobuf.
    */
   encode: function (_msg?: Partial<BarRequest>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarRequest from protobuf.
+   * Deserializes BarRequest from protobuf.
    */
   decode: function (_bytes?: ByteSource): BarRequest {
     return {};
   },
 
   /**
-   * Serializes a BarRequest to JSON.
+   * Serializes BarRequest to JSON.
    */
   encodeJSON: function (_msg?: Partial<BarRequest>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarRequest from JSON.
+   * Deserializes BarRequest from JSON.
    */
   decodeJSON: function (_json?: string): BarRequest {
     return {};
   },
 
   /**
-   * Initializes a BarRequest with all fields set to their default value.
+   * Initializes BarRequest with all fields set to their default value.
    */
   initialize: function (): BarRequest {
     return {};
@@ -112317,35 +112317,35 @@ export const BarRequest = {
 
 export const BarResponse = {
   /**
-   * Serializes a BarResponse to protobuf.
+   * Serializes BarResponse to protobuf.
    */
   encode: function (_msg?: Partial<BarResponse>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a BarResponse from protobuf.
+   * Deserializes BarResponse from protobuf.
    */
   decode: function (_bytes?: ByteSource): BarResponse {
     return {};
   },
 
   /**
-   * Serializes a BarResponse to JSON.
+   * Serializes BarResponse to JSON.
    */
   encodeJSON: function (_msg?: Partial<BarResponse>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a BarResponse from JSON.
+   * Deserializes BarResponse from JSON.
    */
   decodeJSON: function (_json?: string): BarResponse {
     return {};
   },
 
   /**
-   * Initializes a BarResponse with all fields set to their default value.
+   * Initializes BarResponse with all fields set to their default value.
    */
   initialize: function (): BarResponse {
     return {};
@@ -112390,7 +112390,7 @@ export const BarResponse = {
 
 export const TestJsonName = {
   /**
-   * Serializes a TestJsonName to protobuf.
+   * Serializes TestJsonName to protobuf.
    */
   encode: function (msg: Partial<TestJsonName>): Uint8Array {
     return TestJsonName._writeMessage(
@@ -112400,7 +112400,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Deserializes a TestJsonName from protobuf.
+   * Deserializes TestJsonName from protobuf.
    */
   decode: function (bytes: ByteSource): TestJsonName {
     return TestJsonName._readMessage(
@@ -112410,14 +112410,14 @@ export const TestJsonName = {
   },
 
   /**
-   * Serializes a TestJsonName to JSON.
+   * Serializes TestJsonName to JSON.
    */
   encodeJSON: function (msg: Partial<TestJsonName>): string {
     return JSON.stringify(TestJsonName._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestJsonName from JSON.
+   * Deserializes TestJsonName from JSON.
    */
   decodeJSON: function (json: string): TestJsonName {
     return TestJsonName._readMessageJSON(
@@ -112427,7 +112427,7 @@ export const TestJsonName = {
   },
 
   /**
-   * Initializes a TestJsonName with all fields set to their default value.
+   * Initializes TestJsonName with all fields set to their default value.
    */
   initialize: function (): TestJsonName {
     return {
@@ -112588,7 +112588,7 @@ export const TestJsonName = {
 
 export const TestHugeFieldNumbers = {
   /**
-   * Serializes a TestHugeFieldNumbers to protobuf.
+   * Serializes TestHugeFieldNumbers to protobuf.
    */
   encode: function (msg: Partial<TestHugeFieldNumbers>): Uint8Array {
     return TestHugeFieldNumbers._writeMessage(
@@ -112598,7 +112598,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from protobuf.
+   * Deserializes TestHugeFieldNumbers from protobuf.
    */
   decode: function (bytes: ByteSource): TestHugeFieldNumbers {
     return TestHugeFieldNumbers._readMessage(
@@ -112608,14 +112608,14 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Serializes a TestHugeFieldNumbers to JSON.
+   * Serializes TestHugeFieldNumbers to JSON.
    */
   encodeJSON: function (msg: Partial<TestHugeFieldNumbers>): string {
     return JSON.stringify(TestHugeFieldNumbers._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestHugeFieldNumbers from JSON.
+   * Deserializes TestHugeFieldNumbers from JSON.
    */
   decodeJSON: function (json: string): TestHugeFieldNumbers {
     return TestHugeFieldNumbers._readMessageJSON(
@@ -112625,7 +112625,7 @@ export const TestHugeFieldNumbers = {
   },
 
   /**
-   * Initializes a TestHugeFieldNumbers with all fields set to their default value.
+   * Initializes TestHugeFieldNumbers with all fields set to their default value.
    */
   initialize: function (): TestHugeFieldNumbers {
     return {
@@ -112924,7 +112924,7 @@ export const TestHugeFieldNumbers = {
 
   OptionalGroup: {
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to protobuf.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to protobuf.
      */
     encode: function (
       msg: Partial<TestHugeFieldNumbers.OptionalGroup>
@@ -112936,7 +112936,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from protobuf.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from protobuf.
      */
     decode: function (bytes: ByteSource): TestHugeFieldNumbers.OptionalGroup {
       return TestHugeFieldNumbers.OptionalGroup._readMessage(
@@ -112946,7 +112946,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Serializes a TestHugeFieldNumbers.OptionalGroup to JSON.
+     * Serializes TestHugeFieldNumbers.OptionalGroup to JSON.
      */
     encodeJSON: function (
       msg: Partial<TestHugeFieldNumbers.OptionalGroup>
@@ -112957,7 +112957,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Deserializes a TestHugeFieldNumbers.OptionalGroup from JSON.
+     * Deserializes TestHugeFieldNumbers.OptionalGroup from JSON.
      */
     decodeJSON: function (json: string): TestHugeFieldNumbers.OptionalGroup {
       return TestHugeFieldNumbers.OptionalGroup._readMessageJSON(
@@ -112967,7 +112967,7 @@ export const TestHugeFieldNumbers = {
     },
 
     /**
-     * Initializes a TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
+     * Initializes TestHugeFieldNumbers.OptionalGroup with all fields set to their default value.
      */
     initialize: function (): TestHugeFieldNumbers.OptionalGroup {
       return {
@@ -113121,7 +113121,7 @@ export const TestHugeFieldNumbers = {
 
 export const TestExtensionInsideTable = {
   /**
-   * Serializes a TestExtensionInsideTable to protobuf.
+   * Serializes TestExtensionInsideTable to protobuf.
    */
   encode: function (msg: Partial<TestExtensionInsideTable>): Uint8Array {
     return TestExtensionInsideTable._writeMessage(
@@ -113131,7 +113131,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from protobuf.
+   * Deserializes TestExtensionInsideTable from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionInsideTable {
     return TestExtensionInsideTable._readMessage(
@@ -113141,14 +113141,14 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Serializes a TestExtensionInsideTable to JSON.
+   * Serializes TestExtensionInsideTable to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionInsideTable>): string {
     return JSON.stringify(TestExtensionInsideTable._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionInsideTable from JSON.
+   * Deserializes TestExtensionInsideTable from JSON.
    */
   decodeJSON: function (json: string): TestExtensionInsideTable {
     return TestExtensionInsideTable._readMessageJSON(
@@ -113158,7 +113158,7 @@ export const TestExtensionInsideTable = {
   },
 
   /**
-   * Initializes a TestExtensionInsideTable with all fields set to their default value.
+   * Initializes TestExtensionInsideTable with all fields set to their default value.
    */
   initialize: function (): TestExtensionInsideTable {
     return {
@@ -113352,7 +113352,7 @@ export const TestExtensionInsideTable = {
 
 export const TestExtensionRangeSerialize = {
   /**
-   * Serializes a TestExtensionRangeSerialize to protobuf.
+   * Serializes TestExtensionRangeSerialize to protobuf.
    */
   encode: function (msg: Partial<TestExtensionRangeSerialize>): Uint8Array {
     return TestExtensionRangeSerialize._writeMessage(
@@ -113362,7 +113362,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from protobuf.
+   * Deserializes TestExtensionRangeSerialize from protobuf.
    */
   decode: function (bytes: ByteSource): TestExtensionRangeSerialize {
     return TestExtensionRangeSerialize._readMessage(
@@ -113372,14 +113372,14 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Serializes a TestExtensionRangeSerialize to JSON.
+   * Serializes TestExtensionRangeSerialize to JSON.
    */
   encodeJSON: function (msg: Partial<TestExtensionRangeSerialize>): string {
     return JSON.stringify(TestExtensionRangeSerialize._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestExtensionRangeSerialize from JSON.
+   * Deserializes TestExtensionRangeSerialize from JSON.
    */
   decodeJSON: function (json: string): TestExtensionRangeSerialize {
     return TestExtensionRangeSerialize._readMessageJSON(
@@ -113389,7 +113389,7 @@ export const TestExtensionRangeSerialize = {
   },
 
   /**
-   * Initializes a TestExtensionRangeSerialize with all fields set to their default value.
+   * Initializes TestExtensionRangeSerialize with all fields set to their default value.
    */
   initialize: function (): TestExtensionRangeSerialize {
     return {
@@ -113786,35 +113786,35 @@ export const MapEnum = {
 
 export const TestMap = {
   /**
-   * Serializes a TestMap to protobuf.
+   * Serializes TestMap to protobuf.
    */
   encode: function (msg: Partial<TestMap>): Uint8Array {
     return TestMap._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestMap from protobuf.
+   * Deserializes TestMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestMap {
     return TestMap._readMessage(TestMap.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a TestMap to JSON.
+   * Serializes TestMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestMap>): string {
     return JSON.stringify(TestMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMap from JSON.
+   * Deserializes TestMap from JSON.
    */
   decodeJSON: function (json: string): TestMap {
     return TestMap._readMessageJSON(TestMap.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a TestMap with all fields set to their default value.
+   * Initializes TestMap with all fields set to their default value.
    */
   initialize: function (): TestMap {
     return {
@@ -116147,7 +116147,7 @@ export const TestMap = {
 
 export const TestMapSubmessage = {
   /**
-   * Serializes a TestMapSubmessage to protobuf.
+   * Serializes TestMapSubmessage to protobuf.
    */
   encode: function (msg: Partial<TestMapSubmessage>): Uint8Array {
     return TestMapSubmessage._writeMessage(
@@ -116157,7 +116157,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Deserializes a TestMapSubmessage from protobuf.
+   * Deserializes TestMapSubmessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestMapSubmessage {
     return TestMapSubmessage._readMessage(
@@ -116167,14 +116167,14 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Serializes a TestMapSubmessage to JSON.
+   * Serializes TestMapSubmessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestMapSubmessage>): string {
     return JSON.stringify(TestMapSubmessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMapSubmessage from JSON.
+   * Deserializes TestMapSubmessage from JSON.
    */
   decodeJSON: function (json: string): TestMapSubmessage {
     return TestMapSubmessage._readMessageJSON(
@@ -116184,7 +116184,7 @@ export const TestMapSubmessage = {
   },
 
   /**
-   * Initializes a TestMapSubmessage with all fields set to their default value.
+   * Initializes TestMapSubmessage with all fields set to their default value.
    */
   initialize: function (): TestMapSubmessage {
     return {
@@ -116263,7 +116263,7 @@ export const TestMapSubmessage = {
 
 export const TestMessageMap = {
   /**
-   * Serializes a TestMessageMap to protobuf.
+   * Serializes TestMessageMap to protobuf.
    */
   encode: function (msg: Partial<TestMessageMap>): Uint8Array {
     return TestMessageMap._writeMessage(
@@ -116273,7 +116273,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Deserializes a TestMessageMap from protobuf.
+   * Deserializes TestMessageMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestMessageMap {
     return TestMessageMap._readMessage(
@@ -116283,14 +116283,14 @@ export const TestMessageMap = {
   },
 
   /**
-   * Serializes a TestMessageMap to JSON.
+   * Serializes TestMessageMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestMessageMap>): string {
     return JSON.stringify(TestMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageMap from JSON.
+   * Deserializes TestMessageMap from JSON.
    */
   decodeJSON: function (json: string): TestMessageMap {
     return TestMessageMap._readMessageJSON(
@@ -116300,7 +116300,7 @@ export const TestMessageMap = {
   },
 
   /**
-   * Initializes a TestMessageMap with all fields set to their default value.
+   * Initializes TestMessageMap with all fields set to their default value.
    */
   initialize: function (): TestMessageMap {
     return {
@@ -116484,7 +116484,7 @@ export const TestMessageMap = {
 
 export const TestSameTypeMap = {
   /**
-   * Serializes a TestSameTypeMap to protobuf.
+   * Serializes TestSameTypeMap to protobuf.
    */
   encode: function (msg: Partial<TestSameTypeMap>): Uint8Array {
     return TestSameTypeMap._writeMessage(
@@ -116494,7 +116494,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Deserializes a TestSameTypeMap from protobuf.
+   * Deserializes TestSameTypeMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestSameTypeMap {
     return TestSameTypeMap._readMessage(
@@ -116504,14 +116504,14 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Serializes a TestSameTypeMap to JSON.
+   * Serializes TestSameTypeMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestSameTypeMap>): string {
     return JSON.stringify(TestSameTypeMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestSameTypeMap from JSON.
+   * Deserializes TestSameTypeMap from JSON.
    */
   decodeJSON: function (json: string): TestSameTypeMap {
     return TestSameTypeMap._readMessageJSON(
@@ -116521,7 +116521,7 @@ export const TestSameTypeMap = {
   },
 
   /**
-   * Initializes a TestSameTypeMap with all fields set to their default value.
+   * Initializes TestSameTypeMap with all fields set to their default value.
    */
   initialize: function (): TestSameTypeMap {
     return {
@@ -116812,7 +116812,7 @@ export const TestSameTypeMap = {
 
 export const TestRequiredMessageMap = {
   /**
-   * Serializes a TestRequiredMessageMap to protobuf.
+   * Serializes TestRequiredMessageMap to protobuf.
    */
   encode: function (msg: Partial<TestRequiredMessageMap>): Uint8Array {
     return TestRequiredMessageMap._writeMessage(
@@ -116822,7 +116822,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from protobuf.
+   * Deserializes TestRequiredMessageMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestRequiredMessageMap {
     return TestRequiredMessageMap._readMessage(
@@ -116832,14 +116832,14 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Serializes a TestRequiredMessageMap to JSON.
+   * Serializes TestRequiredMessageMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestRequiredMessageMap>): string {
     return JSON.stringify(TestRequiredMessageMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRequiredMessageMap from JSON.
+   * Deserializes TestRequiredMessageMap from JSON.
    */
   decodeJSON: function (json: string): TestRequiredMessageMap {
     return TestRequiredMessageMap._readMessageJSON(
@@ -116849,7 +116849,7 @@ export const TestRequiredMessageMap = {
   },
 
   /**
-   * Initializes a TestRequiredMessageMap with all fields set to their default value.
+   * Initializes TestRequiredMessageMap with all fields set to their default value.
    */
   initialize: function (): TestRequiredMessageMap {
     return {
@@ -117035,7 +117035,7 @@ export const TestRequiredMessageMap = {
 
 export const TestArenaMap = {
   /**
-   * Serializes a TestArenaMap to protobuf.
+   * Serializes TestArenaMap to protobuf.
    */
   encode: function (msg: Partial<TestArenaMap>): Uint8Array {
     return TestArenaMap._writeMessage(
@@ -117045,7 +117045,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Deserializes a TestArenaMap from protobuf.
+   * Deserializes TestArenaMap from protobuf.
    */
   decode: function (bytes: ByteSource): TestArenaMap {
     return TestArenaMap._readMessage(
@@ -117055,14 +117055,14 @@ export const TestArenaMap = {
   },
 
   /**
-   * Serializes a TestArenaMap to JSON.
+   * Serializes TestArenaMap to JSON.
    */
   encodeJSON: function (msg: Partial<TestArenaMap>): string {
     return JSON.stringify(TestArenaMap._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestArenaMap from JSON.
+   * Deserializes TestArenaMap from JSON.
    */
   decodeJSON: function (json: string): TestArenaMap {
     return TestArenaMap._readMessageJSON(
@@ -117072,7 +117072,7 @@ export const TestArenaMap = {
   },
 
   /**
-   * Initializes a TestArenaMap with all fields set to their default value.
+   * Initializes TestArenaMap with all fields set to their default value.
    */
   initialize: function (): TestArenaMap {
     return {
@@ -119179,7 +119179,7 @@ export const TestArenaMap = {
 
 export const MessageContainingMapCalledEntry = {
   /**
-   * Serializes a MessageContainingMapCalledEntry to protobuf.
+   * Serializes MessageContainingMapCalledEntry to protobuf.
    */
   encode: function (msg: Partial<MessageContainingMapCalledEntry>): Uint8Array {
     return MessageContainingMapCalledEntry._writeMessage(
@@ -119189,7 +119189,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from protobuf.
+   * Deserializes MessageContainingMapCalledEntry from protobuf.
    */
   decode: function (bytes: ByteSource): MessageContainingMapCalledEntry {
     return MessageContainingMapCalledEntry._readMessage(
@@ -119199,7 +119199,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Serializes a MessageContainingMapCalledEntry to JSON.
+   * Serializes MessageContainingMapCalledEntry to JSON.
    */
   encodeJSON: function (msg: Partial<MessageContainingMapCalledEntry>): string {
     return JSON.stringify(
@@ -119208,7 +119208,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Deserializes a MessageContainingMapCalledEntry from JSON.
+   * Deserializes MessageContainingMapCalledEntry from JSON.
    */
   decodeJSON: function (json: string): MessageContainingMapCalledEntry {
     return MessageContainingMapCalledEntry._readMessageJSON(
@@ -119218,7 +119218,7 @@ export const MessageContainingMapCalledEntry = {
   },
 
   /**
-   * Initializes a MessageContainingMapCalledEntry with all fields set to their default value.
+   * Initializes MessageContainingMapCalledEntry with all fields set to their default value.
    */
   initialize: function (): MessageContainingMapCalledEntry {
     return {
@@ -119396,7 +119396,7 @@ export const MessageContainingMapCalledEntry = {
 
 export const TestRecursiveMapMessage = {
   /**
-   * Serializes a TestRecursiveMapMessage to protobuf.
+   * Serializes TestRecursiveMapMessage to protobuf.
    */
   encode: function (msg: Partial<TestRecursiveMapMessage>): Uint8Array {
     return TestRecursiveMapMessage._writeMessage(
@@ -119406,7 +119406,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from protobuf.
+   * Deserializes TestRecursiveMapMessage from protobuf.
    */
   decode: function (bytes: ByteSource): TestRecursiveMapMessage {
     return TestRecursiveMapMessage._readMessage(
@@ -119416,14 +119416,14 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Serializes a TestRecursiveMapMessage to JSON.
+   * Serializes TestRecursiveMapMessage to JSON.
    */
   encodeJSON: function (msg: Partial<TestRecursiveMapMessage>): string {
     return JSON.stringify(TestRecursiveMapMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestRecursiveMapMessage from JSON.
+   * Deserializes TestRecursiveMapMessage from JSON.
    */
   decodeJSON: function (json: string): TestRecursiveMapMessage {
     return TestRecursiveMapMessage._readMessageJSON(
@@ -119433,7 +119433,7 @@ export const TestRecursiveMapMessage = {
   },
 
   /**
-   * Initializes a TestRecursiveMapMessage with all fields set to their default value.
+   * Initializes TestRecursiveMapMessage with all fields set to their default value.
    */
   initialize: function (): TestRecursiveMapMessage {
     return {
@@ -119785,35 +119785,35 @@ export interface Any {
 
 export const Any = {
   /**
-   * Serializes a Any to protobuf.
+   * Serializes Any to protobuf.
    */
   encode: function (msg: Partial<Any>): Uint8Array {
     return Any._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Any from protobuf.
+   * Deserializes Any from protobuf.
    */
   decode: function (bytes: ByteSource): Any {
     return Any._readMessage(Any.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Any to JSON.
+   * Serializes Any to JSON.
    */
   encodeJSON: function (msg: Partial<Any>): string {
     return JSON.stringify(Any._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Any from JSON.
+   * Deserializes Any from JSON.
    */
   decodeJSON: function (json: string): Any {
     return Any._readMessageJSON(Any.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Any with all fields set to their default value.
+   * Initializes Any with all fields set to their default value.
    */
   initialize: function (): Any {
     return {
@@ -119943,7 +119943,7 @@ export interface SourceContext {
 
 export const SourceContext = {
   /**
-   * Serializes a SourceContext to protobuf.
+   * Serializes SourceContext to protobuf.
    */
   encode: function (msg: Partial<SourceContext>): Uint8Array {
     return SourceContext._writeMessage(
@@ -119953,7 +119953,7 @@ export const SourceContext = {
   },
 
   /**
-   * Deserializes a SourceContext from protobuf.
+   * Deserializes SourceContext from protobuf.
    */
   decode: function (bytes: ByteSource): SourceContext {
     return SourceContext._readMessage(
@@ -119963,14 +119963,14 @@ export const SourceContext = {
   },
 
   /**
-   * Serializes a SourceContext to JSON.
+   * Serializes SourceContext to JSON.
    */
   encodeJSON: function (msg: Partial<SourceContext>): string {
     return JSON.stringify(SourceContext._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a SourceContext from JSON.
+   * Deserializes SourceContext from JSON.
    */
   decodeJSON: function (json: string): SourceContext {
     return SourceContext._readMessageJSON(
@@ -119980,7 +119980,7 @@ export const SourceContext = {
   },
 
   /**
-   * Initializes a SourceContext with all fields set to their default value.
+   * Initializes SourceContext with all fields set to their default value.
    */
   initialize: function (): SourceContext {
     return {
@@ -120319,35 +120319,35 @@ export const Syntax = {
 
 export const Type = {
   /**
-   * Serializes a Type to protobuf.
+   * Serializes Type to protobuf.
    */
   encode: function (msg: Partial<Type>): Uint8Array {
     return Type._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Type from protobuf.
+   * Deserializes Type from protobuf.
    */
   decode: function (bytes: ByteSource): Type {
     return Type._readMessage(Type.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Type to JSON.
+   * Serializes Type to JSON.
    */
   encodeJSON: function (msg: Partial<Type>): string {
     return JSON.stringify(Type._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Type from JSON.
+   * Deserializes Type from JSON.
    */
   decodeJSON: function (json: string): Type {
     return Type._readMessageJSON(Type.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Type with all fields set to their default value.
+   * Initializes Type with all fields set to their default value.
    */
   initialize: function (): Type {
     return {
@@ -120505,35 +120505,35 @@ export const Type = {
 
 export const Field = {
   /**
-   * Serializes a Field to protobuf.
+   * Serializes Field to protobuf.
    */
   encode: function (msg: Partial<Field>): Uint8Array {
     return Field._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Field from protobuf.
+   * Deserializes Field from protobuf.
    */
   decode: function (bytes: ByteSource): Field {
     return Field._readMessage(Field.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Field to JSON.
+   * Serializes Field to JSON.
    */
   encodeJSON: function (msg: Partial<Field>): string {
     return JSON.stringify(Field._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Field from JSON.
+   * Deserializes Field from JSON.
    */
   decodeJSON: function (json: string): Field {
     return Field._readMessageJSON(Field.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Field with all fields set to their default value.
+   * Initializes Field with all fields set to their default value.
    */
   initialize: function (): Field {
     return {
@@ -121020,35 +121020,35 @@ export const Field = {
 
 export const Enum = {
   /**
-   * Serializes a Enum to protobuf.
+   * Serializes Enum to protobuf.
    */
   encode: function (msg: Partial<Enum>): Uint8Array {
     return Enum._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Enum from protobuf.
+   * Deserializes Enum from protobuf.
    */
   decode: function (bytes: ByteSource): Enum {
     return Enum._readMessage(Enum.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Enum to JSON.
+   * Serializes Enum to JSON.
    */
   encodeJSON: function (msg: Partial<Enum>): string {
     return JSON.stringify(Enum._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Enum from JSON.
+   * Deserializes Enum from JSON.
    */
   decodeJSON: function (json: string): Enum {
     return Enum._readMessageJSON(Enum.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Enum with all fields set to their default value.
+   * Initializes Enum with all fields set to their default value.
    */
   initialize: function (): Enum {
     return {
@@ -121195,14 +121195,14 @@ export const Enum = {
 
 export const EnumValue = {
   /**
-   * Serializes a EnumValue to protobuf.
+   * Serializes EnumValue to protobuf.
    */
   encode: function (msg: Partial<EnumValue>): Uint8Array {
     return EnumValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a EnumValue from protobuf.
+   * Deserializes EnumValue from protobuf.
    */
   decode: function (bytes: ByteSource): EnumValue {
     return EnumValue._readMessage(
@@ -121212,21 +121212,21 @@ export const EnumValue = {
   },
 
   /**
-   * Serializes a EnumValue to JSON.
+   * Serializes EnumValue to JSON.
    */
   encodeJSON: function (msg: Partial<EnumValue>): string {
     return JSON.stringify(EnumValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a EnumValue from JSON.
+   * Deserializes EnumValue from JSON.
    */
   decodeJSON: function (json: string): EnumValue {
     return EnumValue._readMessageJSON(EnumValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a EnumValue with all fields set to their default value.
+   * Initializes EnumValue with all fields set to their default value.
    */
   initialize: function (): EnumValue {
     return {
@@ -121330,35 +121330,35 @@ export const EnumValue = {
 
 export const Option = {
   /**
-   * Serializes a Option to protobuf.
+   * Serializes Option to protobuf.
    */
   encode: function (msg: Partial<Option>): Uint8Array {
     return Option._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Option from protobuf.
+   * Deserializes Option from protobuf.
    */
   decode: function (bytes: ByteSource): Option {
     return Option._readMessage(Option.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Option to JSON.
+   * Serializes Option to JSON.
    */
   encodeJSON: function (msg: Partial<Option>): string {
     return JSON.stringify(Option._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Option from JSON.
+   * Deserializes Option from JSON.
    */
   decodeJSON: function (json: string): Option {
     return Option._readMessageJSON(Option.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Option with all fields set to their default value.
+   * Initializes Option with all fields set to their default value.
    */
   initialize: function (): Option {
     return {
@@ -121674,35 +121674,35 @@ export interface Mixin {
 
 export const Api = {
   /**
-   * Serializes a Api to protobuf.
+   * Serializes Api to protobuf.
    */
   encode: function (msg: Partial<Api>): Uint8Array {
     return Api._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Api from protobuf.
+   * Deserializes Api from protobuf.
    */
   decode: function (bytes: ByteSource): Api {
     return Api._readMessage(Api.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Api to JSON.
+   * Serializes Api to JSON.
    */
   encodeJSON: function (msg: Partial<Api>): string {
     return JSON.stringify(Api._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Api from JSON.
+   * Deserializes Api from JSON.
    */
   decodeJSON: function (json: string): Api {
     return Api._readMessageJSON(Api.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Api with all fields set to their default value.
+   * Initializes Api with all fields set to their default value.
    */
   initialize: function (): Api {
     return {
@@ -121881,35 +121881,35 @@ export const Api = {
 
 export const Method = {
   /**
-   * Serializes a Method to protobuf.
+   * Serializes Method to protobuf.
    */
   encode: function (msg: Partial<Method>): Uint8Array {
     return Method._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Method from protobuf.
+   * Deserializes Method from protobuf.
    */
   decode: function (bytes: ByteSource): Method {
     return Method._readMessage(Method.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Method to JSON.
+   * Serializes Method to JSON.
    */
   encodeJSON: function (msg: Partial<Method>): string {
     return JSON.stringify(Method._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Method from JSON.
+   * Deserializes Method from JSON.
    */
   decodeJSON: function (json: string): Method {
     return Method._readMessageJSON(Method.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Method with all fields set to their default value.
+   * Initializes Method with all fields set to their default value.
    */
   initialize: function (): Method {
     return {
@@ -122072,35 +122072,35 @@ export const Method = {
 
 export const Mixin = {
   /**
-   * Serializes a Mixin to protobuf.
+   * Serializes Mixin to protobuf.
    */
   encode: function (msg: Partial<Mixin>): Uint8Array {
     return Mixin._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Mixin from protobuf.
+   * Deserializes Mixin from protobuf.
    */
   decode: function (bytes: ByteSource): Mixin {
     return Mixin._readMessage(Mixin.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Mixin to JSON.
+   * Serializes Mixin to JSON.
    */
   encodeJSON: function (msg: Partial<Mixin>): string {
     return JSON.stringify(Mixin._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Mixin from JSON.
+   * Deserializes Mixin from JSON.
    */
   decodeJSON: function (json: string): Mixin {
     return Mixin._readMessageJSON(Mixin.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Mixin with all fields set to their default value.
+   * Initializes Mixin with all fields set to their default value.
    */
   initialize: function (): Mixin {
     return {
@@ -122298,14 +122298,14 @@ export interface Duration {
 
 export const Duration = {
   /**
-   * Serializes a Duration to protobuf.
+   * Serializes Duration to protobuf.
    */
   encode: function (msg: Partial<Duration>): Uint8Array {
     return Duration._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Duration from protobuf.
+   * Deserializes Duration from protobuf.
    */
   decode: function (bytes: ByteSource): Duration {
     return Duration._readMessage(
@@ -122315,21 +122315,21 @@ export const Duration = {
   },
 
   /**
-   * Serializes a Duration to JSON.
+   * Serializes Duration to JSON.
    */
   encodeJSON: function (msg: Partial<Duration>): string {
     return JSON.stringify(Duration._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Duration from JSON.
+   * Deserializes Duration from JSON.
    */
   decodeJSON: function (json: string): Duration {
     return Duration._readMessageJSON(Duration.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Duration with all fields set to their default value.
+   * Initializes Duration with all fields set to their default value.
    */
   initialize: function (): Duration {
     return {
@@ -122462,35 +122462,35 @@ export interface Empty {}
 
 export const Empty = {
   /**
-   * Serializes a Empty to protobuf.
+   * Serializes Empty to protobuf.
    */
   encode: function (_msg?: Partial<Empty>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a Empty from protobuf.
+   * Deserializes Empty from protobuf.
    */
   decode: function (_bytes?: ByteSource): Empty {
     return {};
   },
 
   /**
-   * Serializes a Empty to JSON.
+   * Serializes Empty to JSON.
    */
   encodeJSON: function (_msg?: Partial<Empty>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a Empty from JSON.
+   * Deserializes Empty from JSON.
    */
   decodeJSON: function (_json?: string): Empty {
     return {};
   },
 
   /**
-   * Initializes a Empty with all fields set to their default value.
+   * Initializes Empty with all fields set to their default value.
    */
   initialize: function (): Empty {
     return {};
@@ -122775,14 +122775,14 @@ export interface FieldMask {
 
 export const FieldMask = {
   /**
-   * Serializes a FieldMask to protobuf.
+   * Serializes FieldMask to protobuf.
    */
   encode: function (msg: Partial<FieldMask>): Uint8Array {
     return FieldMask._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FieldMask from protobuf.
+   * Deserializes FieldMask from protobuf.
    */
   decode: function (bytes: ByteSource): FieldMask {
     return FieldMask._readMessage(
@@ -122792,21 +122792,21 @@ export const FieldMask = {
   },
 
   /**
-   * Serializes a FieldMask to JSON.
+   * Serializes FieldMask to JSON.
    */
   encodeJSON: function (msg: Partial<FieldMask>): string {
     return JSON.stringify(FieldMask._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FieldMask from JSON.
+   * Deserializes FieldMask from JSON.
    */
   decodeJSON: function (json: string): FieldMask {
     return FieldMask._readMessageJSON(FieldMask.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a FieldMask with all fields set to their default value.
+   * Initializes FieldMask with all fields set to their default value.
    */
   initialize: function (): FieldMask {
     return {
@@ -123022,35 +123022,35 @@ export const NullValue = {
 
 export const Struct = {
   /**
-   * Serializes a Struct to protobuf.
+   * Serializes Struct to protobuf.
    */
   encode: function (msg: Partial<Struct>): Uint8Array {
     return Struct._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Struct from protobuf.
+   * Deserializes Struct from protobuf.
    */
   decode: function (bytes: ByteSource): Struct {
     return Struct._readMessage(Struct.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Struct to JSON.
+   * Serializes Struct to JSON.
    */
   encodeJSON: function (msg: Partial<Struct>): string {
     return JSON.stringify(Struct._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Struct from JSON.
+   * Deserializes Struct from JSON.
    */
   decodeJSON: function (json: string): Struct {
     return Struct._readMessageJSON(Struct.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Struct with all fields set to their default value.
+   * Initializes Struct with all fields set to their default value.
    */
   initialize: function (): Struct {
     return {
@@ -123222,35 +123222,35 @@ export const Struct = {
 
 export const Value = {
   /**
-   * Serializes a Value to protobuf.
+   * Serializes Value to protobuf.
    */
   encode: function (msg: Partial<Value>): Uint8Array {
     return Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Value from protobuf.
+   * Deserializes Value from protobuf.
    */
   decode: function (bytes: ByteSource): Value {
     return Value._readMessage(Value.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Value to JSON.
+   * Serializes Value to JSON.
    */
   encodeJSON: function (msg: Partial<Value>): string {
     return JSON.stringify(Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Value from JSON.
+   * Deserializes Value from JSON.
    */
   decodeJSON: function (json: string): Value {
     return Value._readMessageJSON(Value.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Value with all fields set to their default value.
+   * Initializes Value with all fields set to their default value.
    */
   initialize: function (): Value {
     return {
@@ -123397,14 +123397,14 @@ export const Value = {
 
 export const ListValue = {
   /**
-   * Serializes a ListValue to protobuf.
+   * Serializes ListValue to protobuf.
    */
   encode: function (msg: Partial<ListValue>): Uint8Array {
     return ListValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a ListValue from protobuf.
+   * Deserializes ListValue from protobuf.
    */
   decode: function (bytes: ByteSource): ListValue {
     return ListValue._readMessage(
@@ -123414,21 +123414,21 @@ export const ListValue = {
   },
 
   /**
-   * Serializes a ListValue to JSON.
+   * Serializes ListValue to JSON.
    */
   encodeJSON: function (msg: Partial<ListValue>): string {
     return JSON.stringify(ListValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ListValue from JSON.
+   * Deserializes ListValue from JSON.
    */
   decodeJSON: function (json: string): ListValue {
     return ListValue._readMessageJSON(ListValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a ListValue with all fields set to their default value.
+   * Initializes ListValue with all fields set to their default value.
    */
   initialize: function (): ListValue {
     return {
@@ -123650,14 +123650,14 @@ export interface Timestamp {
 
 export const Timestamp = {
   /**
-   * Serializes a Timestamp to protobuf.
+   * Serializes Timestamp to protobuf.
    */
   encode: function (msg: Partial<Timestamp>): Uint8Array {
     return Timestamp._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Timestamp from protobuf.
+   * Deserializes Timestamp from protobuf.
    */
   decode: function (bytes: ByteSource): Timestamp {
     return Timestamp._readMessage(
@@ -123667,21 +123667,21 @@ export const Timestamp = {
   },
 
   /**
-   * Serializes a Timestamp to JSON.
+   * Serializes Timestamp to JSON.
    */
   encodeJSON: function (msg: Partial<Timestamp>): string {
     return JSON.stringify(Timestamp._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Timestamp from JSON.
+   * Deserializes Timestamp from JSON.
    */
   decodeJSON: function (json: string): Timestamp {
     return Timestamp._readMessageJSON(Timestamp.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Timestamp with all fields set to their default value.
+   * Initializes Timestamp with all fields set to their default value.
    */
   initialize: function (): Timestamp {
     return {
@@ -123914,14 +123914,14 @@ export interface BytesValue {
 
 export const DoubleValue = {
   /**
-   * Serializes a DoubleValue to protobuf.
+   * Serializes DoubleValue to protobuf.
    */
   encode: function (msg: Partial<DoubleValue>): Uint8Array {
     return DoubleValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a DoubleValue from protobuf.
+   * Deserializes DoubleValue from protobuf.
    */
   decode: function (bytes: ByteSource): DoubleValue {
     return DoubleValue._readMessage(
@@ -123931,14 +123931,14 @@ export const DoubleValue = {
   },
 
   /**
-   * Serializes a DoubleValue to JSON.
+   * Serializes DoubleValue to JSON.
    */
   encodeJSON: function (msg: Partial<DoubleValue>): string {
     return JSON.stringify(DoubleValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a DoubleValue from JSON.
+   * Deserializes DoubleValue from JSON.
    */
   decodeJSON: function (json: string): DoubleValue {
     return DoubleValue._readMessageJSON(
@@ -123948,7 +123948,7 @@ export const DoubleValue = {
   },
 
   /**
-   * Initializes a DoubleValue with all fields set to their default value.
+   * Initializes DoubleValue with all fields set to their default value.
    */
   initialize: function (): DoubleValue {
     return {
@@ -124016,14 +124016,14 @@ export const DoubleValue = {
 
 export const FloatValue = {
   /**
-   * Serializes a FloatValue to protobuf.
+   * Serializes FloatValue to protobuf.
    */
   encode: function (msg: Partial<FloatValue>): Uint8Array {
     return FloatValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a FloatValue from protobuf.
+   * Deserializes FloatValue from protobuf.
    */
   decode: function (bytes: ByteSource): FloatValue {
     return FloatValue._readMessage(
@@ -124033,14 +124033,14 @@ export const FloatValue = {
   },
 
   /**
-   * Serializes a FloatValue to JSON.
+   * Serializes FloatValue to JSON.
    */
   encodeJSON: function (msg: Partial<FloatValue>): string {
     return JSON.stringify(FloatValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a FloatValue from JSON.
+   * Deserializes FloatValue from JSON.
    */
   decodeJSON: function (json: string): FloatValue {
     return FloatValue._readMessageJSON(
@@ -124050,7 +124050,7 @@ export const FloatValue = {
   },
 
   /**
-   * Initializes a FloatValue with all fields set to their default value.
+   * Initializes FloatValue with all fields set to their default value.
    */
   initialize: function (): FloatValue {
     return {
@@ -124118,14 +124118,14 @@ export const FloatValue = {
 
 export const Int64Value = {
   /**
-   * Serializes a Int64Value to protobuf.
+   * Serializes Int64Value to protobuf.
    */
   encode: function (msg: Partial<Int64Value>): Uint8Array {
     return Int64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int64Value from protobuf.
+   * Deserializes Int64Value from protobuf.
    */
   decode: function (bytes: ByteSource): Int64Value {
     return Int64Value._readMessage(
@@ -124135,14 +124135,14 @@ export const Int64Value = {
   },
 
   /**
-   * Serializes a Int64Value to JSON.
+   * Serializes Int64Value to JSON.
    */
   encodeJSON: function (msg: Partial<Int64Value>): string {
     return JSON.stringify(Int64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int64Value from JSON.
+   * Deserializes Int64Value from JSON.
    */
   decodeJSON: function (json: string): Int64Value {
     return Int64Value._readMessageJSON(
@@ -124152,7 +124152,7 @@ export const Int64Value = {
   },
 
   /**
-   * Initializes a Int64Value with all fields set to their default value.
+   * Initializes Int64Value with all fields set to their default value.
    */
   initialize: function (): Int64Value {
     return {
@@ -124220,14 +124220,14 @@ export const Int64Value = {
 
 export const UInt64Value = {
   /**
-   * Serializes a UInt64Value to protobuf.
+   * Serializes UInt64Value to protobuf.
    */
   encode: function (msg: Partial<UInt64Value>): Uint8Array {
     return UInt64Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt64Value from protobuf.
+   * Deserializes UInt64Value from protobuf.
    */
   decode: function (bytes: ByteSource): UInt64Value {
     return UInt64Value._readMessage(
@@ -124237,14 +124237,14 @@ export const UInt64Value = {
   },
 
   /**
-   * Serializes a UInt64Value to JSON.
+   * Serializes UInt64Value to JSON.
    */
   encodeJSON: function (msg: Partial<UInt64Value>): string {
     return JSON.stringify(UInt64Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt64Value from JSON.
+   * Deserializes UInt64Value from JSON.
    */
   decodeJSON: function (json: string): UInt64Value {
     return UInt64Value._readMessageJSON(
@@ -124254,7 +124254,7 @@ export const UInt64Value = {
   },
 
   /**
-   * Initializes a UInt64Value with all fields set to their default value.
+   * Initializes UInt64Value with all fields set to their default value.
    */
   initialize: function (): UInt64Value {
     return {
@@ -124322,14 +124322,14 @@ export const UInt64Value = {
 
 export const Int32Value = {
   /**
-   * Serializes a Int32Value to protobuf.
+   * Serializes Int32Value to protobuf.
    */
   encode: function (msg: Partial<Int32Value>): Uint8Array {
     return Int32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Int32Value from protobuf.
+   * Deserializes Int32Value from protobuf.
    */
   decode: function (bytes: ByteSource): Int32Value {
     return Int32Value._readMessage(
@@ -124339,14 +124339,14 @@ export const Int32Value = {
   },
 
   /**
-   * Serializes a Int32Value to JSON.
+   * Serializes Int32Value to JSON.
    */
   encodeJSON: function (msg: Partial<Int32Value>): string {
     return JSON.stringify(Int32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Int32Value from JSON.
+   * Deserializes Int32Value from JSON.
    */
   decodeJSON: function (json: string): Int32Value {
     return Int32Value._readMessageJSON(
@@ -124356,7 +124356,7 @@ export const Int32Value = {
   },
 
   /**
-   * Initializes a Int32Value with all fields set to their default value.
+   * Initializes Int32Value with all fields set to their default value.
    */
   initialize: function (): Int32Value {
     return {
@@ -124424,14 +124424,14 @@ export const Int32Value = {
 
 export const UInt32Value = {
   /**
-   * Serializes a UInt32Value to protobuf.
+   * Serializes UInt32Value to protobuf.
    */
   encode: function (msg: Partial<UInt32Value>): Uint8Array {
     return UInt32Value._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a UInt32Value from protobuf.
+   * Deserializes UInt32Value from protobuf.
    */
   decode: function (bytes: ByteSource): UInt32Value {
     return UInt32Value._readMessage(
@@ -124441,14 +124441,14 @@ export const UInt32Value = {
   },
 
   /**
-   * Serializes a UInt32Value to JSON.
+   * Serializes UInt32Value to JSON.
    */
   encodeJSON: function (msg: Partial<UInt32Value>): string {
     return JSON.stringify(UInt32Value._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a UInt32Value from JSON.
+   * Deserializes UInt32Value from JSON.
    */
   decodeJSON: function (json: string): UInt32Value {
     return UInt32Value._readMessageJSON(
@@ -124458,7 +124458,7 @@ export const UInt32Value = {
   },
 
   /**
-   * Initializes a UInt32Value with all fields set to their default value.
+   * Initializes UInt32Value with all fields set to their default value.
    */
   initialize: function (): UInt32Value {
     return {
@@ -124526,14 +124526,14 @@ export const UInt32Value = {
 
 export const BoolValue = {
   /**
-   * Serializes a BoolValue to protobuf.
+   * Serializes BoolValue to protobuf.
    */
   encode: function (msg: Partial<BoolValue>): Uint8Array {
     return BoolValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BoolValue from protobuf.
+   * Deserializes BoolValue from protobuf.
    */
   decode: function (bytes: ByteSource): BoolValue {
     return BoolValue._readMessage(
@@ -124543,21 +124543,21 @@ export const BoolValue = {
   },
 
   /**
-   * Serializes a BoolValue to JSON.
+   * Serializes BoolValue to JSON.
    */
   encodeJSON: function (msg: Partial<BoolValue>): string {
     return JSON.stringify(BoolValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BoolValue from JSON.
+   * Deserializes BoolValue from JSON.
    */
   decodeJSON: function (json: string): BoolValue {
     return BoolValue._readMessageJSON(BoolValue.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a BoolValue with all fields set to their default value.
+   * Initializes BoolValue with all fields set to their default value.
    */
   initialize: function (): BoolValue {
     return {
@@ -124625,14 +124625,14 @@ export const BoolValue = {
 
 export const StringValue = {
   /**
-   * Serializes a StringValue to protobuf.
+   * Serializes StringValue to protobuf.
    */
   encode: function (msg: Partial<StringValue>): Uint8Array {
     return StringValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a StringValue from protobuf.
+   * Deserializes StringValue from protobuf.
    */
   decode: function (bytes: ByteSource): StringValue {
     return StringValue._readMessage(
@@ -124642,14 +124642,14 @@ export const StringValue = {
   },
 
   /**
-   * Serializes a StringValue to JSON.
+   * Serializes StringValue to JSON.
    */
   encodeJSON: function (msg: Partial<StringValue>): string {
     return JSON.stringify(StringValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a StringValue from JSON.
+   * Deserializes StringValue from JSON.
    */
   decodeJSON: function (json: string): StringValue {
     return StringValue._readMessageJSON(
@@ -124659,7 +124659,7 @@ export const StringValue = {
   },
 
   /**
-   * Initializes a StringValue with all fields set to their default value.
+   * Initializes StringValue with all fields set to their default value.
    */
   initialize: function (): StringValue {
     return {
@@ -124727,14 +124727,14 @@ export const StringValue = {
 
 export const BytesValue = {
   /**
-   * Serializes a BytesValue to protobuf.
+   * Serializes BytesValue to protobuf.
    */
   encode: function (msg: Partial<BytesValue>): Uint8Array {
     return BytesValue._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a BytesValue from protobuf.
+   * Deserializes BytesValue from protobuf.
    */
   decode: function (bytes: ByteSource): BytesValue {
     return BytesValue._readMessage(
@@ -124744,14 +124744,14 @@ export const BytesValue = {
   },
 
   /**
-   * Serializes a BytesValue to JSON.
+   * Serializes BytesValue to JSON.
    */
   encodeJSON: function (msg: Partial<BytesValue>): string {
     return JSON.stringify(BytesValue._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a BytesValue from JSON.
+   * Deserializes BytesValue from JSON.
    */
   decodeJSON: function (json: string): BytesValue {
     return BytesValue._readMessageJSON(
@@ -124761,7 +124761,7 @@ export const BytesValue = {
   },
 
   /**
-   * Initializes a BytesValue with all fields set to their default value.
+   * Initializes BytesValue with all fields set to their default value.
    */
   initialize: function (): BytesValue {
     return {
@@ -125029,7 +125029,7 @@ declare namespace MapWellKnownTypes {
 
 export const TestWellKnownTypes = {
   /**
-   * Serializes a TestWellKnownTypes to protobuf.
+   * Serializes TestWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<TestWellKnownTypes>): Uint8Array {
     return TestWellKnownTypes._writeMessage(
@@ -125039,7 +125039,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from protobuf.
+   * Deserializes TestWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestWellKnownTypes {
     return TestWellKnownTypes._readMessage(
@@ -125049,14 +125049,14 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Serializes a TestWellKnownTypes to JSON.
+   * Serializes TestWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestWellKnownTypes>): string {
     return JSON.stringify(TestWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestWellKnownTypes from JSON.
+   * Deserializes TestWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): TestWellKnownTypes {
     return TestWellKnownTypes._readMessageJSON(
@@ -125066,7 +125066,7 @@ export const TestWellKnownTypes = {
   },
 
   /**
-   * Initializes a TestWellKnownTypes with all fields set to their default value.
+   * Initializes TestWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): TestWellKnownTypes {
     return {
@@ -125515,7 +125515,7 @@ export const TestWellKnownTypes = {
 
 export const RepeatedWellKnownTypes = {
   /**
-   * Serializes a RepeatedWellKnownTypes to protobuf.
+   * Serializes RepeatedWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<RepeatedWellKnownTypes>): Uint8Array {
     return RepeatedWellKnownTypes._writeMessage(
@@ -125525,7 +125525,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from protobuf.
+   * Deserializes RepeatedWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): RepeatedWellKnownTypes {
     return RepeatedWellKnownTypes._readMessage(
@@ -125535,14 +125535,14 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Serializes a RepeatedWellKnownTypes to JSON.
+   * Serializes RepeatedWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<RepeatedWellKnownTypes>): string {
     return JSON.stringify(RepeatedWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a RepeatedWellKnownTypes from JSON.
+   * Deserializes RepeatedWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): RepeatedWellKnownTypes {
     return RepeatedWellKnownTypes._readMessageJSON(
@@ -125552,7 +125552,7 @@ export const RepeatedWellKnownTypes = {
   },
 
   /**
-   * Initializes a RepeatedWellKnownTypes with all fields set to their default value.
+   * Initializes RepeatedWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): RepeatedWellKnownTypes {
     return {
@@ -126052,7 +126052,7 @@ export const RepeatedWellKnownTypes = {
 
 export const OneofWellKnownTypes = {
   /**
-   * Serializes a OneofWellKnownTypes to protobuf.
+   * Serializes OneofWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<OneofWellKnownTypes>): Uint8Array {
     return OneofWellKnownTypes._writeMessage(
@@ -126062,7 +126062,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from protobuf.
+   * Deserializes OneofWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): OneofWellKnownTypes {
     return OneofWellKnownTypes._readMessage(
@@ -126072,14 +126072,14 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Serializes a OneofWellKnownTypes to JSON.
+   * Serializes OneofWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<OneofWellKnownTypes>): string {
     return JSON.stringify(OneofWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a OneofWellKnownTypes from JSON.
+   * Deserializes OneofWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): OneofWellKnownTypes {
     return OneofWellKnownTypes._readMessageJSON(
@@ -126089,7 +126089,7 @@ export const OneofWellKnownTypes = {
   },
 
   /**
-   * Initializes a OneofWellKnownTypes with all fields set to their default value.
+   * Initializes OneofWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): OneofWellKnownTypes {
     return {
@@ -126518,7 +126518,7 @@ export const OneofWellKnownTypes = {
 
 export const MapWellKnownTypes = {
   /**
-   * Serializes a MapWellKnownTypes to protobuf.
+   * Serializes MapWellKnownTypes to protobuf.
    */
   encode: function (msg: Partial<MapWellKnownTypes>): Uint8Array {
     return MapWellKnownTypes._writeMessage(
@@ -126528,7 +126528,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from protobuf.
+   * Deserializes MapWellKnownTypes from protobuf.
    */
   decode: function (bytes: ByteSource): MapWellKnownTypes {
     return MapWellKnownTypes._readMessage(
@@ -126538,14 +126538,14 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Serializes a MapWellKnownTypes to JSON.
+   * Serializes MapWellKnownTypes to JSON.
    */
   encodeJSON: function (msg: Partial<MapWellKnownTypes>): string {
     return JSON.stringify(MapWellKnownTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a MapWellKnownTypes from JSON.
+   * Deserializes MapWellKnownTypes from JSON.
    */
   decodeJSON: function (json: string): MapWellKnownTypes {
     return MapWellKnownTypes._readMessageJSON(
@@ -126555,7 +126555,7 @@ export const MapWellKnownTypes = {
   },
 
   /**
-   * Initializes a MapWellKnownTypes with all fields set to their default value.
+   * Initializes MapWellKnownTypes with all fields set to their default value.
    */
   initialize: function (): MapWellKnownTypes {
     return {
@@ -129139,7 +129139,7 @@ export const ForeignEnum = {
 
 export const TestAllTypes = {
   /**
-   * Serializes a TestAllTypes to protobuf.
+   * Serializes TestAllTypes to protobuf.
    */
   encode: function (msg: Partial<TestAllTypes>): Uint8Array {
     return TestAllTypes._writeMessage(
@@ -129149,7 +129149,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Deserializes a TestAllTypes from protobuf.
+   * Deserializes TestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestAllTypes {
     return TestAllTypes._readMessage(
@@ -129159,14 +129159,14 @@ export const TestAllTypes = {
   },
 
   /**
-   * Serializes a TestAllTypes to JSON.
+   * Serializes TestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestAllTypes>): string {
     return JSON.stringify(TestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestAllTypes from JSON.
+   * Deserializes TestAllTypes from JSON.
    */
   decodeJSON: function (json: string): TestAllTypes {
     return TestAllTypes._readMessageJSON(
@@ -129176,7 +129176,7 @@ export const TestAllTypes = {
   },
 
   /**
-   * Initializes a TestAllTypes with all fields set to their default value.
+   * Initializes TestAllTypes with all fields set to their default value.
    */
   initialize: function (): TestAllTypes {
     return {
@@ -130270,7 +130270,7 @@ export const TestAllTypes = {
 
   NestedMessage: {
     /**
-     * Serializes a TestAllTypes.NestedMessage to protobuf.
+     * Serializes TestAllTypes.NestedMessage to protobuf.
      */
     encode: function (msg: Partial<TestAllTypes.NestedMessage>): Uint8Array {
       return TestAllTypes.NestedMessage._writeMessage(
@@ -130280,7 +130280,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from protobuf.
+     * Deserializes TestAllTypes.NestedMessage from protobuf.
      */
     decode: function (bytes: ByteSource): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessage(
@@ -130290,14 +130290,14 @@ export const TestAllTypes = {
     },
 
     /**
-     * Serializes a TestAllTypes.NestedMessage to JSON.
+     * Serializes TestAllTypes.NestedMessage to JSON.
      */
     encodeJSON: function (msg: Partial<TestAllTypes.NestedMessage>): string {
       return JSON.stringify(TestAllTypes.NestedMessage._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a TestAllTypes.NestedMessage from JSON.
+     * Deserializes TestAllTypes.NestedMessage from JSON.
      */
     decodeJSON: function (json: string): TestAllTypes.NestedMessage {
       return TestAllTypes.NestedMessage._readMessageJSON(
@@ -130307,7 +130307,7 @@ export const TestAllTypes = {
     },
 
     /**
-     * Initializes a TestAllTypes.NestedMessage with all fields set to their default value.
+     * Initializes TestAllTypes.NestedMessage with all fields set to their default value.
      */
     initialize: function (): TestAllTypes.NestedMessage {
       return {
@@ -130382,7 +130382,7 @@ export const TestAllTypes = {
 
 export const TestPackedTypes = {
   /**
-   * Serializes a TestPackedTypes to protobuf.
+   * Serializes TestPackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestPackedTypes>): Uint8Array {
     return TestPackedTypes._writeMessage(
@@ -130392,7 +130392,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Deserializes a TestPackedTypes from protobuf.
+   * Deserializes TestPackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestPackedTypes {
     return TestPackedTypes._readMessage(
@@ -130402,14 +130402,14 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Serializes a TestPackedTypes to JSON.
+   * Serializes TestPackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestPackedTypes>): string {
     return JSON.stringify(TestPackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestPackedTypes from JSON.
+   * Deserializes TestPackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestPackedTypes {
     return TestPackedTypes._readMessageJSON(
@@ -130419,7 +130419,7 @@ export const TestPackedTypes = {
   },
 
   /**
-   * Initializes a TestPackedTypes with all fields set to their default value.
+   * Initializes TestPackedTypes with all fields set to their default value.
    */
   initialize: function (): TestPackedTypes {
     return {
@@ -130703,7 +130703,7 @@ export const TestPackedTypes = {
 
 export const TestUnpackedTypes = {
   /**
-   * Serializes a TestUnpackedTypes to protobuf.
+   * Serializes TestUnpackedTypes to protobuf.
    */
   encode: function (msg: Partial<TestUnpackedTypes>): Uint8Array {
     return TestUnpackedTypes._writeMessage(
@@ -130713,7 +130713,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from protobuf.
+   * Deserializes TestUnpackedTypes from protobuf.
    */
   decode: function (bytes: ByteSource): TestUnpackedTypes {
     return TestUnpackedTypes._readMessage(
@@ -130723,14 +130723,14 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Serializes a TestUnpackedTypes to JSON.
+   * Serializes TestUnpackedTypes to JSON.
    */
   encodeJSON: function (msg: Partial<TestUnpackedTypes>): string {
     return JSON.stringify(TestUnpackedTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestUnpackedTypes from JSON.
+   * Deserializes TestUnpackedTypes from JSON.
    */
   decodeJSON: function (json: string): TestUnpackedTypes {
     return TestUnpackedTypes._readMessageJSON(
@@ -130740,7 +130740,7 @@ export const TestUnpackedTypes = {
   },
 
   /**
-   * Initializes a TestUnpackedTypes with all fields set to their default value.
+   * Initializes TestUnpackedTypes with all fields set to their default value.
    */
   initialize: function (): TestUnpackedTypes {
     return {
@@ -131030,7 +131030,7 @@ export const TestUnpackedTypes = {
 
 export const NestedTestAllTypes = {
   /**
-   * Serializes a NestedTestAllTypes to protobuf.
+   * Serializes NestedTestAllTypes to protobuf.
    */
   encode: function (msg: Partial<NestedTestAllTypes>): Uint8Array {
     return NestedTestAllTypes._writeMessage(
@@ -131040,7 +131040,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from protobuf.
+   * Deserializes NestedTestAllTypes from protobuf.
    */
   decode: function (bytes: ByteSource): NestedTestAllTypes {
     return NestedTestAllTypes._readMessage(
@@ -131050,14 +131050,14 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Serializes a NestedTestAllTypes to JSON.
+   * Serializes NestedTestAllTypes to JSON.
    */
   encodeJSON: function (msg: Partial<NestedTestAllTypes>): string {
     return JSON.stringify(NestedTestAllTypes._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a NestedTestAllTypes from JSON.
+   * Deserializes NestedTestAllTypes from JSON.
    */
   decodeJSON: function (json: string): NestedTestAllTypes {
     return NestedTestAllTypes._readMessageJSON(
@@ -131067,7 +131067,7 @@ export const NestedTestAllTypes = {
   },
 
   /**
-   * Initializes a NestedTestAllTypes with all fields set to their default value.
+   * Initializes NestedTestAllTypes with all fields set to their default value.
    */
   initialize: function (): NestedTestAllTypes {
     return {
@@ -131166,7 +131166,7 @@ export const NestedTestAllTypes = {
 
 export const ForeignMessage = {
   /**
-   * Serializes a ForeignMessage to protobuf.
+   * Serializes ForeignMessage to protobuf.
    */
   encode: function (msg: Partial<ForeignMessage>): Uint8Array {
     return ForeignMessage._writeMessage(
@@ -131176,7 +131176,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Deserializes a ForeignMessage from protobuf.
+   * Deserializes ForeignMessage from protobuf.
    */
   decode: function (bytes: ByteSource): ForeignMessage {
     return ForeignMessage._readMessage(
@@ -131186,14 +131186,14 @@ export const ForeignMessage = {
   },
 
   /**
-   * Serializes a ForeignMessage to JSON.
+   * Serializes ForeignMessage to JSON.
    */
   encodeJSON: function (msg: Partial<ForeignMessage>): string {
     return JSON.stringify(ForeignMessage._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a ForeignMessage from JSON.
+   * Deserializes ForeignMessage from JSON.
    */
   decodeJSON: function (json: string): ForeignMessage {
     return ForeignMessage._readMessageJSON(
@@ -131203,7 +131203,7 @@ export const ForeignMessage = {
   },
 
   /**
-   * Initializes a ForeignMessage with all fields set to their default value.
+   * Initializes ForeignMessage with all fields set to their default value.
    */
   initialize: function (): ForeignMessage {
     return {
@@ -131274,35 +131274,35 @@ export const ForeignMessage = {
 
 export const TestEmptyMessage = {
   /**
-   * Serializes a TestEmptyMessage to protobuf.
+   * Serializes TestEmptyMessage to protobuf.
    */
   encode: function (_msg?: Partial<TestEmptyMessage>): Uint8Array {
     return new Uint8Array();
   },
 
   /**
-   * Deserializes a TestEmptyMessage from protobuf.
+   * Deserializes TestEmptyMessage from protobuf.
    */
   decode: function (_bytes?: ByteSource): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Serializes a TestEmptyMessage to JSON.
+   * Serializes TestEmptyMessage to JSON.
    */
   encodeJSON: function (_msg?: Partial<TestEmptyMessage>): string {
     return \\"{}\\";
   },
 
   /**
-   * Deserializes a TestEmptyMessage from JSON.
+   * Deserializes TestEmptyMessage from JSON.
    */
   decodeJSON: function (_json?: string): TestEmptyMessage {
     return {};
   },
 
   /**
-   * Initializes a TestEmptyMessage with all fields set to their default value.
+   * Initializes TestEmptyMessage with all fields set to their default value.
    */
   initialize: function (): TestEmptyMessage {
     return {};
@@ -131350,7 +131350,7 @@ export const TestEmptyMessage = {
 
 export const TestMessageWithDummy = {
   /**
-   * Serializes a TestMessageWithDummy to protobuf.
+   * Serializes TestMessageWithDummy to protobuf.
    */
   encode: function (msg: Partial<TestMessageWithDummy>): Uint8Array {
     return TestMessageWithDummy._writeMessage(
@@ -131360,7 +131360,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from protobuf.
+   * Deserializes TestMessageWithDummy from protobuf.
    */
   decode: function (bytes: ByteSource): TestMessageWithDummy {
     return TestMessageWithDummy._readMessage(
@@ -131370,14 +131370,14 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Serializes a TestMessageWithDummy to JSON.
+   * Serializes TestMessageWithDummy to JSON.
    */
   encodeJSON: function (msg: Partial<TestMessageWithDummy>): string {
     return JSON.stringify(TestMessageWithDummy._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestMessageWithDummy from JSON.
+   * Deserializes TestMessageWithDummy from JSON.
    */
   decodeJSON: function (json: string): TestMessageWithDummy {
     return TestMessageWithDummy._readMessageJSON(
@@ -131387,7 +131387,7 @@ export const TestMessageWithDummy = {
   },
 
   /**
-   * Initializes a TestMessageWithDummy with all fields set to their default value.
+   * Initializes TestMessageWithDummy with all fields set to their default value.
    */
   initialize: function (): TestMessageWithDummy {
     return {
@@ -131461,14 +131461,14 @@ export const TestMessageWithDummy = {
 
 export const TestOneof2 = {
   /**
-   * Serializes a TestOneof2 to protobuf.
+   * Serializes TestOneof2 to protobuf.
    */
   encode: function (msg: Partial<TestOneof2>): Uint8Array {
     return TestOneof2._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a TestOneof2 from protobuf.
+   * Deserializes TestOneof2 from protobuf.
    */
   decode: function (bytes: ByteSource): TestOneof2 {
     return TestOneof2._readMessage(
@@ -131478,14 +131478,14 @@ export const TestOneof2 = {
   },
 
   /**
-   * Serializes a TestOneof2 to JSON.
+   * Serializes TestOneof2 to JSON.
    */
   encodeJSON: function (msg: Partial<TestOneof2>): string {
     return JSON.stringify(TestOneof2._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a TestOneof2 from JSON.
+   * Deserializes TestOneof2 from JSON.
    */
   decodeJSON: function (json: string): TestOneof2 {
     return TestOneof2._readMessageJSON(
@@ -131495,7 +131495,7 @@ export const TestOneof2 = {
   },
 
   /**
-   * Initializes a TestOneof2 with all fields set to their default value.
+   * Initializes TestOneof2 with all fields set to their default value.
    */
   initialize: function (): TestOneof2 {
     return {};

--- a/src/test-serialization/message.pb.ts
+++ b/src/test-serialization/message.pb.ts
@@ -97,35 +97,35 @@ export const Baz = {
 
 export const Foo = {
   /**
-   * Serializes a Foo to protobuf.
+   * Serializes Foo to protobuf.
    */
   encode: function (msg: Partial<Foo>): Uint8Array {
     return Foo._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Foo from protobuf.
+   * Deserializes Foo from protobuf.
    */
   decode: function (bytes: ByteSource): Foo {
     return Foo._readMessage(Foo.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Foo to JSON.
+   * Serializes Foo to JSON.
    */
   encodeJSON: function (msg: Partial<Foo>): string {
     return JSON.stringify(Foo._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Foo from JSON.
+   * Deserializes Foo from JSON.
    */
   decodeJSON: function (json: string): Foo {
     return Foo._readMessageJSON(Foo.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Foo with all fields set to their default value.
+   * Initializes Foo with all fields set to their default value.
    */
   initialize: function (): Foo {
     return {
@@ -360,7 +360,7 @@ export const Foo = {
 
   FooBar: {
     /**
-     * Serializes a Foo.FooBar to protobuf.
+     * Serializes Foo.FooBar to protobuf.
      */
     encode: function (msg: Partial<Foo.FooBar>): Uint8Array {
       return Foo.FooBar._writeMessage(
@@ -370,7 +370,7 @@ export const Foo = {
     },
 
     /**
-     * Deserializes a Foo.FooBar from protobuf.
+     * Deserializes Foo.FooBar from protobuf.
      */
     decode: function (bytes: ByteSource): Foo.FooBar {
       return Foo.FooBar._readMessage(
@@ -380,14 +380,14 @@ export const Foo = {
     },
 
     /**
-     * Serializes a Foo.FooBar to JSON.
+     * Serializes Foo.FooBar to JSON.
      */
     encodeJSON: function (msg: Partial<Foo.FooBar>): string {
       return JSON.stringify(Foo.FooBar._writeMessageJSON(msg));
     },
 
     /**
-     * Deserializes a Foo.FooBar from JSON.
+     * Deserializes Foo.FooBar from JSON.
      */
     decodeJSON: function (json: string): Foo.FooBar {
       return Foo.FooBar._readMessageJSON(
@@ -397,7 +397,7 @@ export const Foo = {
     },
 
     /**
-     * Initializes a Foo.FooBar with all fields set to their default value.
+     * Initializes Foo.FooBar with all fields set to their default value.
      */
     initialize: function (): Foo.FooBar {
       return {
@@ -681,35 +681,35 @@ export const Foo = {
 
 export const Bar = {
   /**
-   * Serializes a Bar to protobuf.
+   * Serializes Bar to protobuf.
    */
   encode: function (msg: Partial<Bar>): Uint8Array {
     return Bar._writeMessage(msg, new BinaryWriter()).getResultBuffer();
   },
 
   /**
-   * Deserializes a Bar from protobuf.
+   * Deserializes Bar from protobuf.
    */
   decode: function (bytes: ByteSource): Bar {
     return Bar._readMessage(Bar.initialize(), new BinaryReader(bytes));
   },
 
   /**
-   * Serializes a Bar to JSON.
+   * Serializes Bar to JSON.
    */
   encodeJSON: function (msg: Partial<Bar>): string {
     return JSON.stringify(Bar._writeMessageJSON(msg));
   },
 
   /**
-   * Deserializes a Bar from JSON.
+   * Deserializes Bar from JSON.
    */
   decodeJSON: function (json: string): Bar {
     return Bar._readMessageJSON(Bar.initialize(), JSON.parse(json));
   },
 
   /**
-   * Initializes a Bar with all fields set to their default value.
+   * Initializes Bar with all fields set to their default value.
    */
   initialize: function (): Bar {
     return {


### PR DESCRIPTION
avoids needed to inflect for messages starting with a vowel