### PR TITLE
Allow specifying a custom rpcTransport in ClientConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ import { client } from "twirpscript";
 client.rpcTransport = (url, opts) =>
   fetch(url, { ...opts, credentials: "include" });
 
-// setting a (non standard) HTTP "idempotency-key" header for this RPC call. This header will only be sent for this RPC.
+// setting a custom rpcTransport for this RPC call. This transport will only be used for this RPC.
 const hat = await MakeHat(
   { inches: 12 },
   {

--- a/README.md
+++ b/README.md
@@ -276,13 +276,22 @@ console.log(hat);
 
 Twirp abstracts many network details from clients. Sometimes you will want more control over the underlying network request. For these cases, TwirpScript exposes `rpcTransport`.
 
-`rpcTransport` can be used to customize the `fetch` request made. For example, setting `fetch`'s [credentials](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials) option to include (which will include cookies in cross origin requests):
+`rpcTransport` can be used to customize the `fetch` request made. For example, setting `fetch`'s [credentials](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials) option to include (which will include cookies in cross origin requests). `rpcTransport` can be set via _global configuration_ or _call site configuration_:
 
 ```ts
 import { client } from "twirpscript";
 
 client.rpcTransport = (url, opts) =>
   fetch(url, { ...opts, credentials: "include" });
+
+// setting a (non standard) HTTP "idempotency-key" header for this RPC call. This header will only be sent for this RPC.
+const hat = await MakeHat(
+  { inches: 12 },
+  {
+    rpcTransport: (url, opts) =>
+      fetch(url, { ...opts, credentials: "include" }),
+  }
+);
 ```
 
 `rpcTransport` could also be used to replace `fetch` use entirely with something like `axios` or an [https agent](https://nodejs.org/api/https.html#https_class_https_agent).

--- a/src/runtime/client/test.ts
+++ b/src/runtime/client/test.ts
@@ -282,6 +282,17 @@ describe("config", () => {
         );
       });
     });
+
+    it("can provide a custom transport", async () => {
+      const transport = jest.fn(() =>
+        Promise.resolve(mockRpcTransportResponse)
+      );
+
+      await PBrequest("/foo", undefined, { rpcTransport: transport });
+
+      expect(transport).toHaveBeenCalledTimes(1);
+      expect(mockRpcTransport).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe("global", () => {


### PR DESCRIPTION
Hey! 👋 

This PR adds the ability to provide an `rpcTransport` directly at a client call site, so that the client can be changed dynamically for that specific call:

```ts
const hat = await MakeHat({inches: 12}, {rpcTransport: myCustomTransport})
```

I'm using TwirpScript with Cloudflare Workers and am additionally using Twirp to communicate between Workers and [Durable Objects](https://developers.cloudflare.com/workers/learning/using-durable-objects/). Durable Objects [provide a custom `fetch` client](https://developers.cloudflare.com/workers/learning/using-durable-objects/#instantiating-and-communicating-with-a-durable-object) for communicating with that specific object, so I need a way to dynamically choose the transport per call:

```ts
async function example(env) {
  const id = env.OBJECT.idFromName('example')
  const stub = env.OBJECT.get(id)
  return await MakeHat({inches: 12}, {rpcTransport: stub.fetch})
}
```