### PR TITLE
Allow passing additional context to `app()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-          cache: true
       - run: go install github.com/twitchtv/twirp/clientcompat@latest
       - run: npm run test:ci && npx codecov --token=$CODECOV_TOKEN
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run package:build
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+          check-latest: true
+          cache: true
+      - run: go install github.com/twitchtv/twirp/clientcompat@latest
       - run: npm run test:ci && npx codecov --token=$CODECOV_TOKEN
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -343,7 +343,19 @@ createServer(app).listen(PORT, () =>
 
 Your service handlers are invoked with `context` as their second argument. The base fields are documented above, but you may extend this object with arbitrary fields. This means you can use `context` to provide information to your handler that doesn't come from the RPC request itself, such as http headers or server-side API invocations.
 
-Custom fields can be added to the context object via [middleware](#middleware--interceptors).
+Custom fields can be added to the context object via [middleware](#middleware--interceptors) or as the last argument to the `app()` returned from `createTwirpServer` or `createTwirpServerless`:
+
+```ts
+import { createTwirpServerless, InboundRequest } from "twirpscript";
+import { habderdasherHandler } from "./haberdasher";
+
+const app = createTwirpServerless([habderdasherHandler]);
+
+async function handler(request: InboundRequest) {
+  const extraContext = { foo: "bar" };
+  const res = await app(request, extraContext);
+}
+```
 
 ##### Example
 


### PR DESCRIPTION
This PR allows passing additional keys to context as the last argument to the `app()` returned from `createTwirpServer` or `createTwirpServerless`. This allows you to pass external context into the RPC call at the point you invoke the app. I've implemented it for both `TwirpServer` and `TwirpServerless`, but I think it's most useful for `TwirpServerless`, where you are building a custom RPC server on top of TwirpScript:

```ts
const app = createTwirpServerless([...])

export function handler(request: CustomRequestType) {
  const customContext = contextFromRequest(request)
  return app({...}, customContext)
}
```

The types are such that the new generic parameter for `app<Context>()` should only appear if the `extraContext` is provided. And the implementation is such that the extra context is spread into the context before TwirpScript's default context fields and before middleware run, so those existing fields should always have the values they have currently.