### PR TITLE
Give Callers the Ability to set TCP_NODELAY

### DIFF
--- a/packages/twirpscript/src/node/index.ts
+++ b/packages/twirpscript/src/node/index.ts
@@ -1,8 +1,15 @@
 import { RpcTransport } from "../index.js";
+import {
+  RpcTransportOpts,
+  RpcTransportResponse,
+} from "../runtime/client/index.js";
 import * as http from "http";
 import * as https from "https";
 
-export const nodeHttpTransport: RpcTransport = (url, options) => {
+export const nodeHttpTransport: RpcTransport = (
+  url: string,
+  options: RpcTransportOpts,
+): Promise<RpcTransportResponse> => {
   const request = url.startsWith("https") ? https.request : http.request;
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
@@ -31,6 +38,10 @@ export const nodeHttpTransport: RpcTransport = (url, options) => {
         res.on("end", onResolve);
       },
     ).on("error", reject);
+
+    if (options.noDelay) {
+      req.setNoDelay(true);
+    }
 
     req.end(
       options.body instanceof Uint8Array

--- a/packages/twirpscript/src/runtime/client/index.ts
+++ b/packages/twirpscript/src/runtime/client/index.ts
@@ -96,6 +96,7 @@ export interface RpcTransportOpts {
   method: string;
   headers: Record<string, string>;
   body: string | Uint8Array | undefined | null;
+  noDelay?: boolean;
 }
 
 /**


### PR DESCRIPTION
Hey there! I've been using this library and having some performance issues for this specific application and network I'm on. I believe the issue may be due to the fact that [TCP_NODELAY](https://linux.die.net/man/7/tcp) is not enabled.

I'm sure that I'm not the only one who may want this feature, which is enabled in [node's http library](https://nodejs.org/api/http.html#requestsetnodelaynodelay), but not [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) (as far as I can tell)?

This PR also adds type annotations to the `nodeHttpTransport` and fixes up the associated linter errors that occurred as a result.

It is a bit unfortunate that it's asymmetric in nature (i.e. a caller could set `noDelay: true`, but not actually set it if they use the `fetch` RpcTransport). Thoughts on how to potentially improve that?

Thanks! Let me know if there are any questions I can answer!