### PR TITLE
fixed compiler path in compiler.cmd

### DIFF
--- a/packages/twirpscript/src/compiler.cmd
+++ b/packages/twirpscript/src/compiler.cmd
@@ -1,2 +1,2 @@
 @echo off
-node .\node_modules\twirpscript\compiler.js %*
+node .\node_modules\twirpscript\dist\compiler.js %*


### PR DESCRIPTION
The path to `compiler.js` in `compiler.cmd` is missing a `\dist\` in its path.

Current behavior (TwirpScript 0.0.69, ProtoScript 0.0.20) ❌:
```
> npx twirpscript

[TwirpScript]  Protobuf Compiler Error:

node:internal/modules/cjs/loader:1147
  throw err;
  ^

Error: Cannot find module 'D:\...\node_modules\twirpscript\compiler.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.11.0
--protoscript_out: protoc-gen-protoscript: Plugin failed with status code 1.


No .pb.ts files were created or updated.
```

After the suggested fix ✔:
```
> npx twirpscript

[TwirpScript]

0 files created, 0 files updated, 1 file unchanged. 1 file found.
Done in 4.17s.
```

By the way, a similar bug seems to be present in ProtoScript in its sibling `compiler.cmd` file.